### PR TITLE
Update default UserAgent, export api version

### DIFF
--- a/internal/spec/configuration.mustache
+++ b/internal/spec/configuration.mustache
@@ -12,6 +12,10 @@ import (
     {{/-first}}
 {{/servers}}
 
+{{#version}}
+const ApiVersion = "{{.}}"
+{{/version}}
+
 {{#withCustomMiddlewareFunction}}
     // MiddlewareFunction provides way to implement custom middleware.
     type MiddlewareFunction func(*http.Request)
@@ -36,14 +40,14 @@ apiKey			 string
 func NewConfiguration(apiKey string) *Configuration {
 cfg := &Configuration{
 DefaultHeader:    make(map[string]string),
-UserAgent:        "{{{httpUserAgent}}}{{^httpUserAgent}}ccloud-cli/{{{packageVersion}}}{{/httpUserAgent}}",
+UserAgent:        "{{{httpUserAgent}}}{{^httpUserAgent}}ccloud-sdk-go/{{{packageVersion}}}{{/httpUserAgent}}",
 Debug:            false,
 ServerURL:        DefaultServerURL,
 apiKey:			  apiKey,
 }
 
 {{#version}}
-    cfg.AddDefaultHeader("Cc-Version", "{{.}}")
+    cfg.AddDefaultHeader("Cc-Version", ApiVersion)
 {{/version}}
 return cfg
 }

--- a/pkg/client/configuration.go
+++ b/pkg/client/configuration.go
@@ -24,6 +24,8 @@ import (
 
 const DefaultServerURL string = "https://cockroachlabs.cloud"
 
+const ApiVersion = "2022-03-31"
+
 // Configuration stores the configuration of the API client.
 type Configuration struct {
 	Host          string            `json:"host,omitempty"`
@@ -40,13 +42,13 @@ type Configuration struct {
 func NewConfiguration(apiKey string) *Configuration {
 	cfg := &Configuration{
 		DefaultHeader: make(map[string]string),
-		UserAgent:     "ccloud-cli/1.0.0",
+		UserAgent:     "ccloud-sdk-go/1.0.0",
 		Debug:         false,
 		ServerURL:     DefaultServerURL,
 		apiKey:        apiKey,
 	}
 
-	cfg.AddDefaultHeader("Cc-Version", "2022-03-31")
+	cfg.AddDefaultHeader("Cc-Version", ApiVersion)
 	return cfg
 }
 


### PR DESCRIPTION
Previously, the default UserAgent was that used
for the ccloud cli. Now, the default UserAgent
is 'ccloud-sdk-go/\{package version\}'.
This change also exports an api version variable.