### PR TITLE
Remove AdditionalProperties from model structs as it is not used by Cockroach Cloud API

### DIFF
--- a/internal/spec/config.yaml
+++ b/internal/spec/config.yaml
@@ -16,7 +16,7 @@ structPrefix: false
 # https://openapi-generator.tech/docs/usage#generate
 removeOperationIdPrefix: true
 # The 'additionalProperties' implementation is compliant with the OAS and JSON schema specifications.
-disallowAdditionalPropertiesIfNotPresent: false
+disallowAdditionalPropertiesIfNotPresent: true 
 
 # Prefix enum with class name
 enumClassPrefix: true

--- a/pkg/client/model_allowlist_entry.go
+++ b/pkg/client/model_allowlist_entry.go
@@ -24,15 +24,12 @@ import (
 
 // AllowlistEntry struct for AllowlistEntry.
 type AllowlistEntry struct {
-	CidrIp               string  `json:"cidr_ip"`
-	CidrMask             int32   `json:"cidr_mask"`
-	Ui                   bool    `json:"ui"`
-	Sql                  bool    `json:"sql"`
-	Name                 *string `json:"name,omitempty"`
-	AdditionalProperties map[string]interface{}
+	CidrIp   string  `json:"cidr_ip"`
+	CidrMask int32   `json:"cidr_mask"`
+	Ui       bool    `json:"ui"`
+	Sql      bool    `json:"sql"`
+	Name     *string `json:"name,omitempty"`
 }
-
-type allowlistEntry AllowlistEntry
 
 // NewAllowlistEntry instantiates a new AllowlistEntry object.
 // This constructor will assign default values to properties that have it defined,
@@ -146,31 +143,5 @@ func (o AllowlistEntry) MarshalJSON() ([]byte, error) {
 	if o.Name != nil {
 		toSerialize["name"] = o.Name
 	}
-
-	for key, value := range o.AdditionalProperties {
-		toSerialize[key] = value
-	}
-
 	return json.Marshal(toSerialize)
-}
-
-func (o *AllowlistEntry) UnmarshalJSON(bytes []byte) (err error) {
-	varAllowlistEntry := allowlistEntry{}
-
-	if err = json.Unmarshal(bytes, &varAllowlistEntry); err == nil {
-		*o = AllowlistEntry(varAllowlistEntry)
-	}
-
-	additionalProperties := make(map[string]interface{})
-
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
-		delete(additionalProperties, "cidr_ip")
-		delete(additionalProperties, "cidr_mask")
-		delete(additionalProperties, "ui")
-		delete(additionalProperties, "sql")
-		delete(additionalProperties, "name")
-		o.AdditionalProperties = additionalProperties
-	}
-
-	return err
 }

--- a/pkg/client/model_allowlist_entry_1.go
+++ b/pkg/client/model_allowlist_entry_1.go
@@ -24,13 +24,10 @@ import (
 
 // AllowlistEntry1 struct for AllowlistEntry1.
 type AllowlistEntry1 struct {
-	Ui                   bool    `json:"ui"`
-	Sql                  bool    `json:"sql"`
-	Name                 *string `json:"name,omitempty"`
-	AdditionalProperties map[string]interface{}
+	Ui   bool    `json:"ui"`
+	Sql  bool    `json:"sql"`
+	Name *string `json:"name,omitempty"`
 }
-
-type allowlistEntry1 AllowlistEntry1
 
 // NewAllowlistEntry1 instantiates a new AllowlistEntry1 object.
 // This constructor will assign default values to properties that have it defined,
@@ -106,29 +103,5 @@ func (o AllowlistEntry1) MarshalJSON() ([]byte, error) {
 	if o.Name != nil {
 		toSerialize["name"] = o.Name
 	}
-
-	for key, value := range o.AdditionalProperties {
-		toSerialize[key] = value
-	}
-
 	return json.Marshal(toSerialize)
-}
-
-func (o *AllowlistEntry1) UnmarshalJSON(bytes []byte) (err error) {
-	varAllowlistEntry1 := allowlistEntry1{}
-
-	if err = json.Unmarshal(bytes, &varAllowlistEntry1); err == nil {
-		*o = AllowlistEntry1(varAllowlistEntry1)
-	}
-
-	additionalProperties := make(map[string]interface{})
-
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
-		delete(additionalProperties, "ui")
-		delete(additionalProperties, "sql")
-		delete(additionalProperties, "name")
-		o.AdditionalProperties = additionalProperties
-	}
-
-	return err
 }

--- a/pkg/client/model_api_database.go
+++ b/pkg/client/model_api_database.go
@@ -24,12 +24,9 @@ import (
 
 // ApiDatabase struct for ApiDatabase.
 type ApiDatabase struct {
-	Name                 string  `json:"name"`
-	TableCount           *string `json:"table_count,omitempty"`
-	AdditionalProperties map[string]interface{}
+	Name       string  `json:"name"`
+	TableCount *string `json:"table_count,omitempty"`
 }
-
-type apiDatabase ApiDatabase
 
 // NewApiDatabase instantiates a new ApiDatabase object.
 // This constructor will assign default values to properties that have it defined,
@@ -86,28 +83,5 @@ func (o ApiDatabase) MarshalJSON() ([]byte, error) {
 	if o.TableCount != nil {
 		toSerialize["table_count"] = o.TableCount
 	}
-
-	for key, value := range o.AdditionalProperties {
-		toSerialize[key] = value
-	}
-
 	return json.Marshal(toSerialize)
-}
-
-func (o *ApiDatabase) UnmarshalJSON(bytes []byte) (err error) {
-	varApiDatabase := apiDatabase{}
-
-	if err = json.Unmarshal(bytes, &varApiDatabase); err == nil {
-		*o = ApiDatabase(varApiDatabase)
-	}
-
-	additionalProperties := make(map[string]interface{})
-
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
-		delete(additionalProperties, "name")
-		delete(additionalProperties, "table_count")
-		o.AdditionalProperties = additionalProperties
-	}
-
-	return err
 }

--- a/pkg/client/model_api_list_databases_response.go
+++ b/pkg/client/model_api_list_databases_response.go
@@ -24,12 +24,9 @@ import (
 
 // ApiListDatabasesResponse struct for ApiListDatabasesResponse.
 type ApiListDatabasesResponse struct {
-	Databases            []ApiDatabase             `json:"databases"`
-	Pagination           *KeysetPaginationResponse `json:"pagination,omitempty"`
-	AdditionalProperties map[string]interface{}
+	Databases  []ApiDatabase             `json:"databases"`
+	Pagination *KeysetPaginationResponse `json:"pagination,omitempty"`
 }
-
-type apiListDatabasesResponse ApiListDatabasesResponse
 
 // NewApiListDatabasesResponse instantiates a new ApiListDatabasesResponse object.
 // This constructor will assign default values to properties that have it defined,
@@ -86,28 +83,5 @@ func (o ApiListDatabasesResponse) MarshalJSON() ([]byte, error) {
 	if o.Pagination != nil {
 		toSerialize["pagination"] = o.Pagination
 	}
-
-	for key, value := range o.AdditionalProperties {
-		toSerialize[key] = value
-	}
-
 	return json.Marshal(toSerialize)
-}
-
-func (o *ApiListDatabasesResponse) UnmarshalJSON(bytes []byte) (err error) {
-	varApiListDatabasesResponse := apiListDatabasesResponse{}
-
-	if err = json.Unmarshal(bytes, &varApiListDatabasesResponse); err == nil {
-		*o = ApiListDatabasesResponse(varApiListDatabasesResponse)
-	}
-
-	additionalProperties := make(map[string]interface{})
-
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
-		delete(additionalProperties, "databases")
-		delete(additionalProperties, "pagination")
-		o.AdditionalProperties = additionalProperties
-	}
-
-	return err
 }

--- a/pkg/client/model_aws_endpoint_connection.go
+++ b/pkg/client/model_aws_endpoint_connection.go
@@ -31,11 +31,8 @@ type AwsEndpointConnection struct {
 	// EndpointID is the client side of the PrivateLink connection.
 	EndpointId string `json:"endpoint_id"`
 	// ServiceID is the server side of the PrivateLink connection. This is the same as AWSPrivateLinkEndpoint.service_id.
-	ServiceId            string `json:"service_id"`
-	AdditionalProperties map[string]interface{}
+	ServiceId string `json:"service_id"`
 }
-
-type awsEndpointConnection AwsEndpointConnection
 
 // NewAwsEndpointConnection instantiates a new AwsEndpointConnection object.
 // This constructor will assign default values to properties that have it defined,
@@ -151,31 +148,5 @@ func (o AwsEndpointConnection) MarshalJSON() ([]byte, error) {
 	if true {
 		toSerialize["service_id"] = o.ServiceId
 	}
-
-	for key, value := range o.AdditionalProperties {
-		toSerialize[key] = value
-	}
-
 	return json.Marshal(toSerialize)
-}
-
-func (o *AwsEndpointConnection) UnmarshalJSON(bytes []byte) (err error) {
-	varAwsEndpointConnection := awsEndpointConnection{}
-
-	if err = json.Unmarshal(bytes, &varAwsEndpointConnection); err == nil {
-		*o = AwsEndpointConnection(varAwsEndpointConnection)
-	}
-
-	additionalProperties := make(map[string]interface{})
-
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
-		delete(additionalProperties, "region_name")
-		delete(additionalProperties, "cloud_provider")
-		delete(additionalProperties, "status")
-		delete(additionalProperties, "endpoint_id")
-		delete(additionalProperties, "service_id")
-		o.AdditionalProperties = additionalProperties
-	}
-
-	return err
 }

--- a/pkg/client/model_aws_endpoint_connections.go
+++ b/pkg/client/model_aws_endpoint_connections.go
@@ -25,11 +25,8 @@ import (
 // AwsEndpointConnections struct for AwsEndpointConnections.
 type AwsEndpointConnections struct {
 	// Connections is a list of private endpoints.
-	Connections          []AwsEndpointConnection `json:"connections"`
-	AdditionalProperties map[string]interface{}
+	Connections []AwsEndpointConnection `json:"connections"`
 }
-
-type awsEndpointConnections AwsEndpointConnections
 
 // NewAwsEndpointConnections instantiates a new AwsEndpointConnections object.
 // This constructor will assign default values to properties that have it defined,
@@ -69,27 +66,5 @@ func (o AwsEndpointConnections) MarshalJSON() ([]byte, error) {
 	if true {
 		toSerialize["connections"] = o.Connections
 	}
-
-	for key, value := range o.AdditionalProperties {
-		toSerialize[key] = value
-	}
-
 	return json.Marshal(toSerialize)
-}
-
-func (o *AwsEndpointConnections) UnmarshalJSON(bytes []byte) (err error) {
-	varAwsEndpointConnections := awsEndpointConnections{}
-
-	if err = json.Unmarshal(bytes, &varAwsEndpointConnections); err == nil {
-		*o = AwsEndpointConnections(varAwsEndpointConnections)
-	}
-
-	additionalProperties := make(map[string]interface{})
-
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
-		delete(additionalProperties, "connections")
-		o.AdditionalProperties = additionalProperties
-	}
-
-	return err
 }

--- a/pkg/client/model_aws_private_link_service_detail.go
+++ b/pkg/client/model_aws_private_link_service_detail.go
@@ -29,11 +29,8 @@ type AWSPrivateLinkServiceDetail struct {
 	// ServiceID is the server side of the PrivateLink connection. This is the same as AWSPrivateLinkEndpoint.service_id.
 	ServiceId string `json:"service_id"`
 	// AvailabilityZoneIDs are the identifiers for the availability zones that the service is available in.
-	AvailabilityZoneIds  []string `json:"availability_zone_ids"`
-	AdditionalProperties map[string]interface{}
+	AvailabilityZoneIds []string `json:"availability_zone_ids"`
 }
-
-type aWSPrivateLinkServiceDetail AWSPrivateLinkServiceDetail
 
 // NewAWSPrivateLinkServiceDetail instantiates a new AWSPrivateLinkServiceDetail object.
 // This constructor will assign default values to properties that have it defined,
@@ -111,29 +108,5 @@ func (o AWSPrivateLinkServiceDetail) MarshalJSON() ([]byte, error) {
 	if true {
 		toSerialize["availability_zone_ids"] = o.AvailabilityZoneIds
 	}
-
-	for key, value := range o.AdditionalProperties {
-		toSerialize[key] = value
-	}
-
 	return json.Marshal(toSerialize)
-}
-
-func (o *AWSPrivateLinkServiceDetail) UnmarshalJSON(bytes []byte) (err error) {
-	varAWSPrivateLinkServiceDetail := aWSPrivateLinkServiceDetail{}
-
-	if err = json.Unmarshal(bytes, &varAWSPrivateLinkServiceDetail); err == nil {
-		*o = AWSPrivateLinkServiceDetail(varAWSPrivateLinkServiceDetail)
-	}
-
-	additionalProperties := make(map[string]interface{})
-
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
-		delete(additionalProperties, "service_name")
-		delete(additionalProperties, "service_id")
-		delete(additionalProperties, "availability_zone_ids")
-		o.AdditionalProperties = additionalProperties
-	}
-
-	return err
 }

--- a/pkg/client/model_cloud_provider_region.go
+++ b/pkg/client/model_cloud_provider_region.go
@@ -24,15 +24,12 @@ import (
 
 // CloudProviderRegion struct for CloudProviderRegion.
 type CloudProviderRegion struct {
-	Name                 string           `json:"name"`
-	Location             string           `json:"location"`
-	Provider             ApiCloudProvider `json:"provider"`
-	Serverless           bool             `json:"serverless"`
-	Distance             float32          `json:"distance"`
-	AdditionalProperties map[string]interface{}
+	Name       string           `json:"name"`
+	Location   string           `json:"location"`
+	Provider   ApiCloudProvider `json:"provider"`
+	Serverless bool             `json:"serverless"`
+	Distance   float32          `json:"distance"`
 }
-
-type cloudProviderRegion CloudProviderRegion
 
 // NewCloudProviderRegion instantiates a new CloudProviderRegion object.
 // This constructor will assign default values to properties that have it defined,
@@ -148,31 +145,5 @@ func (o CloudProviderRegion) MarshalJSON() ([]byte, error) {
 	if true {
 		toSerialize["distance"] = o.Distance
 	}
-
-	for key, value := range o.AdditionalProperties {
-		toSerialize[key] = value
-	}
-
 	return json.Marshal(toSerialize)
-}
-
-func (o *CloudProviderRegion) UnmarshalJSON(bytes []byte) (err error) {
-	varCloudProviderRegion := cloudProviderRegion{}
-
-	if err = json.Unmarshal(bytes, &varCloudProviderRegion); err == nil {
-		*o = CloudProviderRegion(varCloudProviderRegion)
-	}
-
-	additionalProperties := make(map[string]interface{})
-
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
-		delete(additionalProperties, "name")
-		delete(additionalProperties, "location")
-		delete(additionalProperties, "provider")
-		delete(additionalProperties, "serverless")
-		delete(additionalProperties, "distance")
-		o.AdditionalProperties = additionalProperties
-	}
-
-	return err
 }

--- a/pkg/client/model_cluster.go
+++ b/pkg/client/model_cluster.go
@@ -25,24 +25,21 @@ import (
 
 // Cluster struct for Cluster.
 type Cluster struct {
-	Id                   string            `json:"id"`
-	Name                 string            `json:"name"`
-	CockroachVersion     string            `json:"cockroach_version"`
-	Plan                 Plan              `json:"plan"`
-	CloudProvider        ApiCloudProvider  `json:"cloud_provider"`
-	AccountId            *string           `json:"account_id,omitempty"`
-	State                ClusterStateType  `json:"state"`
-	CreatorId            string            `json:"creator_id"`
-	OperationStatus      ClusterStatusType `json:"operation_status"`
-	Config               ClusterConfig     `json:"config"`
-	Regions              []Region          `json:"regions"`
-	CreatedAt            *time.Time        `json:"created_at,omitempty"`
-	UpdatedAt            *time.Time        `json:"updated_at,omitempty"`
-	DeletedAt            *time.Time        `json:"deleted_at,omitempty"`
-	AdditionalProperties map[string]interface{}
+	Id               string            `json:"id"`
+	Name             string            `json:"name"`
+	CockroachVersion string            `json:"cockroach_version"`
+	Plan             Plan              `json:"plan"`
+	CloudProvider    ApiCloudProvider  `json:"cloud_provider"`
+	AccountId        *string           `json:"account_id,omitempty"`
+	State            ClusterStateType  `json:"state"`
+	CreatorId        string            `json:"creator_id"`
+	OperationStatus  ClusterStatusType `json:"operation_status"`
+	Config           ClusterConfig     `json:"config"`
+	Regions          []Region          `json:"regions"`
+	CreatedAt        *time.Time        `json:"created_at,omitempty"`
+	UpdatedAt        *time.Time        `json:"updated_at,omitempty"`
+	DeletedAt        *time.Time        `json:"deleted_at,omitempty"`
 }
-
-type cluster Cluster
 
 // NewCluster instantiates a new Cluster object.
 // This constructor will assign default values to properties that have it defined,
@@ -321,40 +318,5 @@ func (o Cluster) MarshalJSON() ([]byte, error) {
 	if o.DeletedAt != nil {
 		toSerialize["deleted_at"] = o.DeletedAt
 	}
-
-	for key, value := range o.AdditionalProperties {
-		toSerialize[key] = value
-	}
-
 	return json.Marshal(toSerialize)
-}
-
-func (o *Cluster) UnmarshalJSON(bytes []byte) (err error) {
-	varCluster := cluster{}
-
-	if err = json.Unmarshal(bytes, &varCluster); err == nil {
-		*o = Cluster(varCluster)
-	}
-
-	additionalProperties := make(map[string]interface{})
-
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
-		delete(additionalProperties, "id")
-		delete(additionalProperties, "name")
-		delete(additionalProperties, "cockroach_version")
-		delete(additionalProperties, "plan")
-		delete(additionalProperties, "cloud_provider")
-		delete(additionalProperties, "account_id")
-		delete(additionalProperties, "state")
-		delete(additionalProperties, "creator_id")
-		delete(additionalProperties, "operation_status")
-		delete(additionalProperties, "config")
-		delete(additionalProperties, "regions")
-		delete(additionalProperties, "created_at")
-		delete(additionalProperties, "updated_at")
-		delete(additionalProperties, "deleted_at")
-		o.AdditionalProperties = additionalProperties
-	}
-
-	return err
 }

--- a/pkg/client/model_cluster_config.go
+++ b/pkg/client/model_cluster_config.go
@@ -24,12 +24,9 @@ import (
 
 // ClusterConfig struct for ClusterConfig.
 type ClusterConfig struct {
-	Dedicated            *DedicatedHardwareConfig `json:"dedicated,omitempty"`
-	Serverless           *ServerlessClusterConfig `json:"serverless,omitempty"`
-	AdditionalProperties map[string]interface{}
+	Dedicated  *DedicatedHardwareConfig `json:"dedicated,omitempty"`
+	Serverless *ServerlessClusterConfig `json:"serverless,omitempty"`
 }
-
-type clusterConfig ClusterConfig
 
 // NewClusterConfig instantiates a new ClusterConfig object.
 // This constructor will assign default values to properties that have it defined,
@@ -76,28 +73,5 @@ func (o ClusterConfig) MarshalJSON() ([]byte, error) {
 	if o.Serverless != nil {
 		toSerialize["serverless"] = o.Serverless
 	}
-
-	for key, value := range o.AdditionalProperties {
-		toSerialize[key] = value
-	}
-
 	return json.Marshal(toSerialize)
-}
-
-func (o *ClusterConfig) UnmarshalJSON(bytes []byte) (err error) {
-	varClusterConfig := clusterConfig{}
-
-	if err = json.Unmarshal(bytes, &varClusterConfig); err == nil {
-		*o = ClusterConfig(varClusterConfig)
-	}
-
-	additionalProperties := make(map[string]interface{})
-
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
-		delete(additionalProperties, "dedicated")
-		delete(additionalProperties, "serverless")
-		o.AdditionalProperties = additionalProperties
-	}
-
-	return err
 }

--- a/pkg/client/model_cmek_cluster_info.go
+++ b/pkg/client/model_cmek_cluster_info.go
@@ -24,12 +24,9 @@ import (
 
 // CMEKClusterInfo CMEKClusterInfo contains the status of CMEK across an entire cluster, including within each one its regions..
 type CMEKClusterInfo struct {
-	Status               *CMEKStatus       `json:"status,omitempty"`
-	RegionInfos          *[]CMEKRegionInfo `json:"region_infos,omitempty"`
-	AdditionalProperties map[string]interface{}
+	Status      *CMEKStatus       `json:"status,omitempty"`
+	RegionInfos *[]CMEKRegionInfo `json:"region_infos,omitempty"`
 }
-
-type cMEKClusterInfo CMEKClusterInfo
 
 // NewCMEKClusterInfo instantiates a new CMEKClusterInfo object.
 // This constructor will assign default values to properties that have it defined,
@@ -76,28 +73,5 @@ func (o CMEKClusterInfo) MarshalJSON() ([]byte, error) {
 	if o.RegionInfos != nil {
 		toSerialize["region_infos"] = o.RegionInfos
 	}
-
-	for key, value := range o.AdditionalProperties {
-		toSerialize[key] = value
-	}
-
 	return json.Marshal(toSerialize)
-}
-
-func (o *CMEKClusterInfo) UnmarshalJSON(bytes []byte) (err error) {
-	varCMEKClusterInfo := cMEKClusterInfo{}
-
-	if err = json.Unmarshal(bytes, &varCMEKClusterInfo); err == nil {
-		*o = CMEKClusterInfo(varCMEKClusterInfo)
-	}
-
-	additionalProperties := make(map[string]interface{})
-
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
-		delete(additionalProperties, "status")
-		delete(additionalProperties, "region_infos")
-		o.AdditionalProperties = additionalProperties
-	}
-
-	return err
 }

--- a/pkg/client/model_cmek_cluster_specification.go
+++ b/pkg/client/model_cmek_cluster_specification.go
@@ -24,11 +24,8 @@ import (
 
 // CMEKClusterSpecification struct for CMEKClusterSpecification.
 type CMEKClusterSpecification struct {
-	RegionSpecs          []CMEKRegionSpecification `json:"region_specs"`
-	AdditionalProperties map[string]interface{}
+	RegionSpecs []CMEKRegionSpecification `json:"region_specs"`
 }
-
-type cMEKClusterSpecification CMEKClusterSpecification
 
 // NewCMEKClusterSpecification instantiates a new CMEKClusterSpecification object.
 // This constructor will assign default values to properties that have it defined,
@@ -68,27 +65,5 @@ func (o CMEKClusterSpecification) MarshalJSON() ([]byte, error) {
 	if true {
 		toSerialize["region_specs"] = o.RegionSpecs
 	}
-
-	for key, value := range o.AdditionalProperties {
-		toSerialize[key] = value
-	}
-
 	return json.Marshal(toSerialize)
-}
-
-func (o *CMEKClusterSpecification) UnmarshalJSON(bytes []byte) (err error) {
-	varCMEKClusterSpecification := cMEKClusterSpecification{}
-
-	if err = json.Unmarshal(bytes, &varCMEKClusterSpecification); err == nil {
-		*o = CMEKClusterSpecification(varCMEKClusterSpecification)
-	}
-
-	additionalProperties := make(map[string]interface{})
-
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
-		delete(additionalProperties, "region_specs")
-		o.AdditionalProperties = additionalProperties
-	}
-
-	return err
 }

--- a/pkg/client/model_cmek_key_info.go
+++ b/pkg/client/model_cmek_key_info.go
@@ -25,15 +25,12 @@ import (
 
 // CMEKKeyInfo CMEKKeyInfo contains the status of a customer-provided key alongside the specification..
 type CMEKKeyInfo struct {
-	Status               *CMEKStatus           `json:"status,omitempty"`
-	UserMessage          *string               `json:"user_message,omitempty"`
-	Spec                 *CMEKKeySpecification `json:"spec,omitempty"`
-	CreatedAt            *time.Time            `json:"created_at,omitempty"`
-	UpdatedAt            *time.Time            `json:"updated_at,omitempty"`
-	AdditionalProperties map[string]interface{}
+	Status      *CMEKStatus           `json:"status,omitempty"`
+	UserMessage *string               `json:"user_message,omitempty"`
+	Spec        *CMEKKeySpecification `json:"spec,omitempty"`
+	CreatedAt   *time.Time            `json:"created_at,omitempty"`
+	UpdatedAt   *time.Time            `json:"updated_at,omitempty"`
 }
-
-type cMEKKeyInfo CMEKKeyInfo
 
 // NewCMEKKeyInfo instantiates a new CMEKKeyInfo object.
 // This constructor will assign default values to properties that have it defined,
@@ -131,31 +128,5 @@ func (o CMEKKeyInfo) MarshalJSON() ([]byte, error) {
 	if o.UpdatedAt != nil {
 		toSerialize["updated_at"] = o.UpdatedAt
 	}
-
-	for key, value := range o.AdditionalProperties {
-		toSerialize[key] = value
-	}
-
 	return json.Marshal(toSerialize)
-}
-
-func (o *CMEKKeyInfo) UnmarshalJSON(bytes []byte) (err error) {
-	varCMEKKeyInfo := cMEKKeyInfo{}
-
-	if err = json.Unmarshal(bytes, &varCMEKKeyInfo); err == nil {
-		*o = CMEKKeyInfo(varCMEKKeyInfo)
-	}
-
-	additionalProperties := make(map[string]interface{})
-
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
-		delete(additionalProperties, "status")
-		delete(additionalProperties, "user_message")
-		delete(additionalProperties, "spec")
-		delete(additionalProperties, "created_at")
-		delete(additionalProperties, "updated_at")
-		o.AdditionalProperties = additionalProperties
-	}
-
-	return err
 }

--- a/pkg/client/model_cmek_key_specification.go
+++ b/pkg/client/model_cmek_key_specification.go
@@ -24,13 +24,10 @@ import (
 
 // CMEKKeySpecification CMEKKeySpecification contains all the details necessary to use a customer-provided encryption key. This involves the type/location of the key and the principal to authenticate as when accessing it..
 type CMEKKeySpecification struct {
-	Type                 *CMEKKeyType `json:"type,omitempty"`
-	Uri                  *string      `json:"uri,omitempty"`
-	AuthPrincipal        *string      `json:"auth_principal,omitempty"`
-	AdditionalProperties map[string]interface{}
+	Type          *CMEKKeyType `json:"type,omitempty"`
+	Uri           *string      `json:"uri,omitempty"`
+	AuthPrincipal *string      `json:"auth_principal,omitempty"`
 }
-
-type cMEKKeySpecification CMEKKeySpecification
 
 // NewCMEKKeySpecification instantiates a new CMEKKeySpecification object.
 // This constructor will assign default values to properties that have it defined,
@@ -94,29 +91,5 @@ func (o CMEKKeySpecification) MarshalJSON() ([]byte, error) {
 	if o.AuthPrincipal != nil {
 		toSerialize["auth_principal"] = o.AuthPrincipal
 	}
-
-	for key, value := range o.AdditionalProperties {
-		toSerialize[key] = value
-	}
-
 	return json.Marshal(toSerialize)
-}
-
-func (o *CMEKKeySpecification) UnmarshalJSON(bytes []byte) (err error) {
-	varCMEKKeySpecification := cMEKKeySpecification{}
-
-	if err = json.Unmarshal(bytes, &varCMEKKeySpecification); err == nil {
-		*o = CMEKKeySpecification(varCMEKKeySpecification)
-	}
-
-	additionalProperties := make(map[string]interface{})
-
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
-		delete(additionalProperties, "type")
-		delete(additionalProperties, "uri")
-		delete(additionalProperties, "auth_principal")
-		o.AdditionalProperties = additionalProperties
-	}
-
-	return err
 }

--- a/pkg/client/model_cmek_region_info.go
+++ b/pkg/client/model_cmek_region_info.go
@@ -24,13 +24,10 @@ import (
 
 // CMEKRegionInfo CMEKRegionInfo contains the status of CMEK within a region. This includes current and past key specifications used within the region, as well as the status of those specifications..
 type CMEKRegionInfo struct {
-	Region               *string        `json:"region,omitempty"`
-	Status               *CMEKStatus    `json:"status,omitempty"`
-	KeyInfos             *[]CMEKKeyInfo `json:"key_infos,omitempty"`
-	AdditionalProperties map[string]interface{}
+	Region   *string        `json:"region,omitempty"`
+	Status   *CMEKStatus    `json:"status,omitempty"`
+	KeyInfos *[]CMEKKeyInfo `json:"key_infos,omitempty"`
 }
-
-type cMEKRegionInfo CMEKRegionInfo
 
 // NewCMEKRegionInfo instantiates a new CMEKRegionInfo object.
 // This constructor will assign default values to properties that have it defined,
@@ -94,29 +91,5 @@ func (o CMEKRegionInfo) MarshalJSON() ([]byte, error) {
 	if o.KeyInfos != nil {
 		toSerialize["key_infos"] = o.KeyInfos
 	}
-
-	for key, value := range o.AdditionalProperties {
-		toSerialize[key] = value
-	}
-
 	return json.Marshal(toSerialize)
-}
-
-func (o *CMEKRegionInfo) UnmarshalJSON(bytes []byte) (err error) {
-	varCMEKRegionInfo := cMEKRegionInfo{}
-
-	if err = json.Unmarshal(bytes, &varCMEKRegionInfo); err == nil {
-		*o = CMEKRegionInfo(varCMEKRegionInfo)
-	}
-
-	additionalProperties := make(map[string]interface{})
-
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
-		delete(additionalProperties, "region")
-		delete(additionalProperties, "status")
-		delete(additionalProperties, "key_infos")
-		o.AdditionalProperties = additionalProperties
-	}
-
-	return err
 }

--- a/pkg/client/model_cmek_region_specification.go
+++ b/pkg/client/model_cmek_region_specification.go
@@ -24,12 +24,9 @@ import (
 
 // CMEKRegionSpecification CMEKRegionSpecification declares the customer-provided key specification that should be used in a given region..
 type CMEKRegionSpecification struct {
-	Region               *string               `json:"region,omitempty"`
-	KeySpec              *CMEKKeySpecification `json:"key_spec,omitempty"`
-	AdditionalProperties map[string]interface{}
+	Region  *string               `json:"region,omitempty"`
+	KeySpec *CMEKKeySpecification `json:"key_spec,omitempty"`
 }
-
-type cMEKRegionSpecification CMEKRegionSpecification
 
 // NewCMEKRegionSpecification instantiates a new CMEKRegionSpecification object.
 // This constructor will assign default values to properties that have it defined,
@@ -76,28 +73,5 @@ func (o CMEKRegionSpecification) MarshalJSON() ([]byte, error) {
 	if o.KeySpec != nil {
 		toSerialize["key_spec"] = o.KeySpec
 	}
-
-	for key, value := range o.AdditionalProperties {
-		toSerialize[key] = value
-	}
-
 	return json.Marshal(toSerialize)
-}
-
-func (o *CMEKRegionSpecification) UnmarshalJSON(bytes []byte) (err error) {
-	varCMEKRegionSpecification := cMEKRegionSpecification{}
-
-	if err = json.Unmarshal(bytes, &varCMEKRegionSpecification); err == nil {
-		*o = CMEKRegionSpecification(varCMEKRegionSpecification)
-	}
-
-	additionalProperties := make(map[string]interface{})
-
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
-		delete(additionalProperties, "region")
-		delete(additionalProperties, "key_spec")
-		o.AdditionalProperties = additionalProperties
-	}
-
-	return err
 }

--- a/pkg/client/model_cockroach_cloud_set_aws_endpoint_connection_state_request.go
+++ b/pkg/client/model_cockroach_cloud_set_aws_endpoint_connection_state_request.go
@@ -24,11 +24,8 @@ import (
 
 // CockroachCloudSetAwsEndpointConnectionStateRequest struct for CockroachCloudSetAwsEndpointConnectionStateRequest.
 type CockroachCloudSetAwsEndpointConnectionStateRequest struct {
-	Status               *AWSEndpointConnectionStatus `json:"status,omitempty"`
-	AdditionalProperties map[string]interface{}
+	Status *AWSEndpointConnectionStatus `json:"status,omitempty"`
 }
-
-type cockroachCloudSetAwsEndpointConnectionStateRequest CockroachCloudSetAwsEndpointConnectionStateRequest
 
 // NewCockroachCloudSetAwsEndpointConnectionStateRequest instantiates a new CockroachCloudSetAwsEndpointConnectionStateRequest object.
 // This constructor will assign default values to properties that have it defined,
@@ -58,27 +55,5 @@ func (o CockroachCloudSetAwsEndpointConnectionStateRequest) MarshalJSON() ([]byt
 	if o.Status != nil {
 		toSerialize["status"] = o.Status
 	}
-
-	for key, value := range o.AdditionalProperties {
-		toSerialize[key] = value
-	}
-
 	return json.Marshal(toSerialize)
-}
-
-func (o *CockroachCloudSetAwsEndpointConnectionStateRequest) UnmarshalJSON(bytes []byte) (err error) {
-	varCockroachCloudSetAwsEndpointConnectionStateRequest := cockroachCloudSetAwsEndpointConnectionStateRequest{}
-
-	if err = json.Unmarshal(bytes, &varCockroachCloudSetAwsEndpointConnectionStateRequest); err == nil {
-		*o = CockroachCloudSetAwsEndpointConnectionStateRequest(varCockroachCloudSetAwsEndpointConnectionStateRequest)
-	}
-
-	additionalProperties := make(map[string]interface{})
-
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
-		delete(additionalProperties, "status")
-		o.AdditionalProperties = additionalProperties
-	}
-
-	return err
 }

--- a/pkg/client/model_create_cluster_request.go
+++ b/pkg/client/model_create_cluster_request.go
@@ -25,13 +25,10 @@ import (
 // CreateClusterRequest struct for CreateClusterRequest.
 type CreateClusterRequest struct {
 	// Name must be 6-20 characters in length and can include numbers, lowercase letters, and dashes (but no leading or trailing dashes).
-	Name                 string                     `json:"name"`
-	Provider             ApiCloudProvider           `json:"provider"`
-	Spec                 CreateClusterSpecification `json:"spec"`
-	AdditionalProperties map[string]interface{}
+	Name     string                     `json:"name"`
+	Provider ApiCloudProvider           `json:"provider"`
+	Spec     CreateClusterSpecification `json:"spec"`
 }
-
-type createClusterRequest CreateClusterRequest
 
 // NewCreateClusterRequest instantiates a new CreateClusterRequest object.
 // This constructor will assign default values to properties that have it defined,
@@ -109,29 +106,5 @@ func (o CreateClusterRequest) MarshalJSON() ([]byte, error) {
 	if true {
 		toSerialize["spec"] = o.Spec
 	}
-
-	for key, value := range o.AdditionalProperties {
-		toSerialize[key] = value
-	}
-
 	return json.Marshal(toSerialize)
-}
-
-func (o *CreateClusterRequest) UnmarshalJSON(bytes []byte) (err error) {
-	varCreateClusterRequest := createClusterRequest{}
-
-	if err = json.Unmarshal(bytes, &varCreateClusterRequest); err == nil {
-		*o = CreateClusterRequest(varCreateClusterRequest)
-	}
-
-	additionalProperties := make(map[string]interface{})
-
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
-		delete(additionalProperties, "name")
-		delete(additionalProperties, "provider")
-		delete(additionalProperties, "spec")
-		o.AdditionalProperties = additionalProperties
-	}
-
-	return err
 }

--- a/pkg/client/model_create_cluster_specification.go
+++ b/pkg/client/model_create_cluster_specification.go
@@ -24,12 +24,9 @@ import (
 
 // CreateClusterSpecification struct for CreateClusterSpecification.
 type CreateClusterSpecification struct {
-	Dedicated            *DedicatedClusterCreateSpecification  `json:"dedicated,omitempty"`
-	Serverless           *ServerlessClusterCreateSpecification `json:"serverless,omitempty"`
-	AdditionalProperties map[string]interface{}
+	Dedicated  *DedicatedClusterCreateSpecification  `json:"dedicated,omitempty"`
+	Serverless *ServerlessClusterCreateSpecification `json:"serverless,omitempty"`
 }
-
-type createClusterSpecification CreateClusterSpecification
 
 // NewCreateClusterSpecification instantiates a new CreateClusterSpecification object.
 // This constructor will assign default values to properties that have it defined,
@@ -76,28 +73,5 @@ func (o CreateClusterSpecification) MarshalJSON() ([]byte, error) {
 	if o.Serverless != nil {
 		toSerialize["serverless"] = o.Serverless
 	}
-
-	for key, value := range o.AdditionalProperties {
-		toSerialize[key] = value
-	}
-
 	return json.Marshal(toSerialize)
-}
-
-func (o *CreateClusterSpecification) UnmarshalJSON(bytes []byte) (err error) {
-	varCreateClusterSpecification := createClusterSpecification{}
-
-	if err = json.Unmarshal(bytes, &varCreateClusterSpecification); err == nil {
-		*o = CreateClusterSpecification(varCreateClusterSpecification)
-	}
-
-	additionalProperties := make(map[string]interface{})
-
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
-		delete(additionalProperties, "dedicated")
-		delete(additionalProperties, "serverless")
-		o.AdditionalProperties = additionalProperties
-	}
-
-	return err
 }

--- a/pkg/client/model_create_database_request.go
+++ b/pkg/client/model_create_database_request.go
@@ -24,11 +24,8 @@ import (
 
 // CreateDatabaseRequest struct for CreateDatabaseRequest.
 type CreateDatabaseRequest struct {
-	Name                 string `json:"name"`
-	AdditionalProperties map[string]interface{}
+	Name string `json:"name"`
 }
-
-type createDatabaseRequest CreateDatabaseRequest
 
 // NewCreateDatabaseRequest instantiates a new CreateDatabaseRequest object.
 // This constructor will assign default values to properties that have it defined,
@@ -68,27 +65,5 @@ func (o CreateDatabaseRequest) MarshalJSON() ([]byte, error) {
 	if true {
 		toSerialize["name"] = o.Name
 	}
-
-	for key, value := range o.AdditionalProperties {
-		toSerialize[key] = value
-	}
-
 	return json.Marshal(toSerialize)
-}
-
-func (o *CreateDatabaseRequest) UnmarshalJSON(bytes []byte) (err error) {
-	varCreateDatabaseRequest := createDatabaseRequest{}
-
-	if err = json.Unmarshal(bytes, &varCreateDatabaseRequest); err == nil {
-		*o = CreateDatabaseRequest(varCreateDatabaseRequest)
-	}
-
-	additionalProperties := make(map[string]interface{})
-
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
-		delete(additionalProperties, "name")
-		o.AdditionalProperties = additionalProperties
-	}
-
-	return err
 }

--- a/pkg/client/model_create_sql_user_request.go
+++ b/pkg/client/model_create_sql_user_request.go
@@ -24,12 +24,9 @@ import (
 
 // CreateSQLUserRequest struct for CreateSQLUserRequest.
 type CreateSQLUserRequest struct {
-	Name                 string `json:"name"`
-	Password             string `json:"password"`
-	AdditionalProperties map[string]interface{}
+	Name     string `json:"name"`
+	Password string `json:"password"`
 }
-
-type createSQLUserRequest CreateSQLUserRequest
 
 // NewCreateSQLUserRequest instantiates a new CreateSQLUserRequest object.
 // This constructor will assign default values to properties that have it defined,
@@ -88,28 +85,5 @@ func (o CreateSQLUserRequest) MarshalJSON() ([]byte, error) {
 	if true {
 		toSerialize["password"] = o.Password
 	}
-
-	for key, value := range o.AdditionalProperties {
-		toSerialize[key] = value
-	}
-
 	return json.Marshal(toSerialize)
-}
-
-func (o *CreateSQLUserRequest) UnmarshalJSON(bytes []byte) (err error) {
-	varCreateSQLUserRequest := createSQLUserRequest{}
-
-	if err = json.Unmarshal(bytes, &varCreateSQLUserRequest); err == nil {
-		*o = CreateSQLUserRequest(varCreateSQLUserRequest)
-	}
-
-	additionalProperties := make(map[string]interface{})
-
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
-		delete(additionalProperties, "name")
-		delete(additionalProperties, "password")
-		o.AdditionalProperties = additionalProperties
-	}
-
-	return err
 }

--- a/pkg/client/model_currency_amount.go
+++ b/pkg/client/model_currency_amount.go
@@ -25,12 +25,9 @@ import (
 // CurrencyAmount struct for CurrencyAmount.
 type CurrencyAmount struct {
 	// Amount is the quantity of currency.
-	Amount               *float64  `json:"amount,omitempty"`
-	Currency             *Currency `json:"currency,omitempty"`
-	AdditionalProperties map[string]interface{}
+	Amount   *float64  `json:"amount,omitempty"`
+	Currency *Currency `json:"currency,omitempty"`
 }
-
-type currencyAmount CurrencyAmount
 
 // NewCurrencyAmount instantiates a new CurrencyAmount object.
 // This constructor will assign default values to properties that have it defined,
@@ -77,28 +74,5 @@ func (o CurrencyAmount) MarshalJSON() ([]byte, error) {
 	if o.Currency != nil {
 		toSerialize["currency"] = o.Currency
 	}
-
-	for key, value := range o.AdditionalProperties {
-		toSerialize[key] = value
-	}
-
 	return json.Marshal(toSerialize)
-}
-
-func (o *CurrencyAmount) UnmarshalJSON(bytes []byte) (err error) {
-	varCurrencyAmount := currencyAmount{}
-
-	if err = json.Unmarshal(bytes, &varCurrencyAmount); err == nil {
-		*o = CurrencyAmount(varCurrencyAmount)
-	}
-
-	additionalProperties := make(map[string]interface{})
-
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
-		delete(additionalProperties, "amount")
-		delete(additionalProperties, "currency")
-		o.AdditionalProperties = additionalProperties
-	}
-
-	return err
 }

--- a/pkg/client/model_dedicated_cluster_create_specification.go
+++ b/pkg/client/model_dedicated_cluster_create_specification.go
@@ -28,11 +28,8 @@ type DedicatedClusterCreateSpecification struct {
 	RegionNodes map[string]int32                     `json:"region_nodes"`
 	Hardware    DedicatedHardwareCreateSpecification `json:"hardware"`
 	// The CockroachDB version for the cluster. The current version is used if omitted.
-	CockroachVersion     *string `json:"cockroach_version,omitempty"`
-	AdditionalProperties map[string]interface{}
+	CockroachVersion *string `json:"cockroach_version,omitempty"`
 }
-
-type dedicatedClusterCreateSpecification DedicatedClusterCreateSpecification
 
 // NewDedicatedClusterCreateSpecification instantiates a new DedicatedClusterCreateSpecification object.
 // This constructor will assign default values to properties that have it defined,
@@ -108,29 +105,5 @@ func (o DedicatedClusterCreateSpecification) MarshalJSON() ([]byte, error) {
 	if o.CockroachVersion != nil {
 		toSerialize["cockroach_version"] = o.CockroachVersion
 	}
-
-	for key, value := range o.AdditionalProperties {
-		toSerialize[key] = value
-	}
-
 	return json.Marshal(toSerialize)
-}
-
-func (o *DedicatedClusterCreateSpecification) UnmarshalJSON(bytes []byte) (err error) {
-	varDedicatedClusterCreateSpecification := dedicatedClusterCreateSpecification{}
-
-	if err = json.Unmarshal(bytes, &varDedicatedClusterCreateSpecification); err == nil {
-		*o = DedicatedClusterCreateSpecification(varDedicatedClusterCreateSpecification)
-	}
-
-	additionalProperties := make(map[string]interface{})
-
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
-		delete(additionalProperties, "region_nodes")
-		delete(additionalProperties, "hardware")
-		delete(additionalProperties, "cockroach_version")
-		o.AdditionalProperties = additionalProperties
-	}
-
-	return err
 }

--- a/pkg/client/model_dedicated_cluster_update_specification.go
+++ b/pkg/client/model_dedicated_cluster_update_specification.go
@@ -28,11 +28,8 @@ type DedicatedClusterUpdateSpecification struct {
 	RegionNodes *map[string]int32                     `json:"region_nodes,omitempty"`
 	Hardware    *DedicatedHardwareUpdateSpecification `json:"hardware,omitempty"`
 	// This field should contain the CMEK specs for newly added regions. If a CMEK spec is provided for an existing region, the request is invalid and will fail.
-	CmekRegionSpecs      *[]CMEKRegionSpecification `json:"cmek_region_specs,omitempty"`
-	AdditionalProperties map[string]interface{}
+	CmekRegionSpecs *[]CMEKRegionSpecification `json:"cmek_region_specs,omitempty"`
 }
-
-type dedicatedClusterUpdateSpecification DedicatedClusterUpdateSpecification
 
 // NewDedicatedClusterUpdateSpecification instantiates a new DedicatedClusterUpdateSpecification object.
 // This constructor will assign default values to properties that have it defined,
@@ -96,29 +93,5 @@ func (o DedicatedClusterUpdateSpecification) MarshalJSON() ([]byte, error) {
 	if o.CmekRegionSpecs != nil {
 		toSerialize["cmek_region_specs"] = o.CmekRegionSpecs
 	}
-
-	for key, value := range o.AdditionalProperties {
-		toSerialize[key] = value
-	}
-
 	return json.Marshal(toSerialize)
-}
-
-func (o *DedicatedClusterUpdateSpecification) UnmarshalJSON(bytes []byte) (err error) {
-	varDedicatedClusterUpdateSpecification := dedicatedClusterUpdateSpecification{}
-
-	if err = json.Unmarshal(bytes, &varDedicatedClusterUpdateSpecification); err == nil {
-		*o = DedicatedClusterUpdateSpecification(varDedicatedClusterUpdateSpecification)
-	}
-
-	additionalProperties := make(map[string]interface{})
-
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
-		delete(additionalProperties, "region_nodes")
-		delete(additionalProperties, "hardware")
-		delete(additionalProperties, "cmek_region_specs")
-		o.AdditionalProperties = additionalProperties
-	}
-
-	return err
 }

--- a/pkg/client/model_dedicated_hardware_config.go
+++ b/pkg/client/model_dedicated_hardware_config.go
@@ -33,11 +33,8 @@ type DedicatedHardwareConfig struct {
 	// MemoryGiB is the memory GiB per node in the cluster.
 	MemoryGib float32 `json:"memory_gib"`
 	// DiskIOPs is the number of disk I/O operations per second that are permitted on each node in the cluster. Zero indicates the cloud provider-specific default.
-	DiskIops             int32 `json:"disk_iops"`
-	AdditionalProperties map[string]interface{}
+	DiskIops int32 `json:"disk_iops"`
 }
-
-type dedicatedHardwareConfig DedicatedHardwareConfig
 
 // NewDedicatedHardwareConfig instantiates a new DedicatedHardwareConfig object.
 // This constructor will assign default values to properties that have it defined,
@@ -153,31 +150,5 @@ func (o DedicatedHardwareConfig) MarshalJSON() ([]byte, error) {
 	if true {
 		toSerialize["disk_iops"] = o.DiskIops
 	}
-
-	for key, value := range o.AdditionalProperties {
-		toSerialize[key] = value
-	}
-
 	return json.Marshal(toSerialize)
-}
-
-func (o *DedicatedHardwareConfig) UnmarshalJSON(bytes []byte) (err error) {
-	varDedicatedHardwareConfig := dedicatedHardwareConfig{}
-
-	if err = json.Unmarshal(bytes, &varDedicatedHardwareConfig); err == nil {
-		*o = DedicatedHardwareConfig(varDedicatedHardwareConfig)
-	}
-
-	additionalProperties := make(map[string]interface{})
-
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
-		delete(additionalProperties, "machine_type")
-		delete(additionalProperties, "num_virtual_cpus")
-		delete(additionalProperties, "storage_gib")
-		delete(additionalProperties, "memory_gib")
-		delete(additionalProperties, "disk_iops")
-		o.AdditionalProperties = additionalProperties
-	}
-
-	return err
 }

--- a/pkg/client/model_dedicated_hardware_create_specification.go
+++ b/pkg/client/model_dedicated_hardware_create_specification.go
@@ -28,11 +28,8 @@ type DedicatedHardwareCreateSpecification struct {
 	// StorageGiB is the number of storage GiB per node in the cluster. Zero indicates default to the lowest storage GiB available given machine specs.
 	StorageGib int32 `json:"storage_gib"`
 	// DiskIOPs is the number of disk I/O operations per second that are permitted on each node in the cluster. Zero indicates the cloud provider-specific default. Only available for AWS clusters.
-	DiskIops             *int32 `json:"disk_iops,omitempty"`
-	AdditionalProperties map[string]interface{}
+	DiskIops *int32 `json:"disk_iops,omitempty"`
 }
-
-type dedicatedHardwareCreateSpecification DedicatedHardwareCreateSpecification
 
 // NewDedicatedHardwareCreateSpecification instantiates a new DedicatedHardwareCreateSpecification object.
 // This constructor will assign default values to properties that have it defined,
@@ -108,29 +105,5 @@ func (o DedicatedHardwareCreateSpecification) MarshalJSON() ([]byte, error) {
 	if o.DiskIops != nil {
 		toSerialize["disk_iops"] = o.DiskIops
 	}
-
-	for key, value := range o.AdditionalProperties {
-		toSerialize[key] = value
-	}
-
 	return json.Marshal(toSerialize)
-}
-
-func (o *DedicatedHardwareCreateSpecification) UnmarshalJSON(bytes []byte) (err error) {
-	varDedicatedHardwareCreateSpecification := dedicatedHardwareCreateSpecification{}
-
-	if err = json.Unmarshal(bytes, &varDedicatedHardwareCreateSpecification); err == nil {
-		*o = DedicatedHardwareCreateSpecification(varDedicatedHardwareCreateSpecification)
-	}
-
-	additionalProperties := make(map[string]interface{})
-
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
-		delete(additionalProperties, "machine_spec")
-		delete(additionalProperties, "storage_gib")
-		delete(additionalProperties, "disk_iops")
-		o.AdditionalProperties = additionalProperties
-	}
-
-	return err
 }

--- a/pkg/client/model_dedicated_hardware_update_specification.go
+++ b/pkg/client/model_dedicated_hardware_update_specification.go
@@ -28,11 +28,8 @@ type DedicatedHardwareUpdateSpecification struct {
 	// StorageGiB is the number of storage GiB per node in the cluster.
 	StorageGib *int32 `json:"storage_gib,omitempty"`
 	// DiskIOPs is the number of disk I/O operations per second that are permitted on each node in the cluster. Zero indicates the cloud provider-specific default. Only available for AWS clusters.
-	DiskIops             *int32 `json:"disk_iops,omitempty"`
-	AdditionalProperties map[string]interface{}
+	DiskIops *int32 `json:"disk_iops,omitempty"`
 }
-
-type dedicatedHardwareUpdateSpecification DedicatedHardwareUpdateSpecification
 
 // NewDedicatedHardwareUpdateSpecification instantiates a new DedicatedHardwareUpdateSpecification object.
 // This constructor will assign default values to properties that have it defined,
@@ -96,29 +93,5 @@ func (o DedicatedHardwareUpdateSpecification) MarshalJSON() ([]byte, error) {
 	if o.DiskIops != nil {
 		toSerialize["disk_iops"] = o.DiskIops
 	}
-
-	for key, value := range o.AdditionalProperties {
-		toSerialize[key] = value
-	}
-
 	return json.Marshal(toSerialize)
-}
-
-func (o *DedicatedHardwareUpdateSpecification) UnmarshalJSON(bytes []byte) (err error) {
-	varDedicatedHardwareUpdateSpecification := dedicatedHardwareUpdateSpecification{}
-
-	if err = json.Unmarshal(bytes, &varDedicatedHardwareUpdateSpecification); err == nil {
-		*o = DedicatedHardwareUpdateSpecification(varDedicatedHardwareUpdateSpecification)
-	}
-
-	additionalProperties := make(map[string]interface{})
-
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
-		delete(additionalProperties, "machine_spec")
-		delete(additionalProperties, "storage_gib")
-		delete(additionalProperties, "disk_iops")
-		o.AdditionalProperties = additionalProperties
-	}
-
-	return err
 }

--- a/pkg/client/model_dedicated_machine_type_specification.go
+++ b/pkg/client/model_dedicated_machine_type_specification.go
@@ -27,11 +27,8 @@ type DedicatedMachineTypeSpecification struct {
 	// MachineType is the machine type identifier within the given cloud provider, ex. m5.xlarge, n2-standard-4.
 	MachineType *string `json:"machine_type,omitempty"`
 	// NumVirtualCPUs may be used to automatically select a machine type according to the desired number of vCPUs.
-	NumVirtualCpus       *int32 `json:"num_virtual_cpus,omitempty"`
-	AdditionalProperties map[string]interface{}
+	NumVirtualCpus *int32 `json:"num_virtual_cpus,omitempty"`
 }
-
-type dedicatedMachineTypeSpecification DedicatedMachineTypeSpecification
 
 // NewDedicatedMachineTypeSpecification instantiates a new DedicatedMachineTypeSpecification object.
 // This constructor will assign default values to properties that have it defined,
@@ -78,28 +75,5 @@ func (o DedicatedMachineTypeSpecification) MarshalJSON() ([]byte, error) {
 	if o.NumVirtualCpus != nil {
 		toSerialize["num_virtual_cpus"] = o.NumVirtualCpus
 	}
-
-	for key, value := range o.AdditionalProperties {
-		toSerialize[key] = value
-	}
-
 	return json.Marshal(toSerialize)
-}
-
-func (o *DedicatedMachineTypeSpecification) UnmarshalJSON(bytes []byte) (err error) {
-	varDedicatedMachineTypeSpecification := dedicatedMachineTypeSpecification{}
-
-	if err = json.Unmarshal(bytes, &varDedicatedMachineTypeSpecification); err == nil {
-		*o = DedicatedMachineTypeSpecification(varDedicatedMachineTypeSpecification)
-	}
-
-	additionalProperties := make(map[string]interface{})
-
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
-		delete(additionalProperties, "machine_type")
-		delete(additionalProperties, "num_virtual_cpus")
-		o.AdditionalProperties = additionalProperties
-	}
-
-	return err
 }

--- a/pkg/client/model_enable_log_export_request.go
+++ b/pkg/client/model_enable_log_export_request.go
@@ -28,11 +28,8 @@ type EnableLogExportRequest struct {
 	// log_name is an identifier for the logs in the customer's log sink.
 	LogName *string `json:"log_name,omitempty"`
 	// auth_principal is either the AWS Role ARN that identifies a role that the cluster account can assume to write to CloudWatch or the GCP Project ID that the cluster service account has permissions to write to for cloud logging.
-	AuthPrincipal        *string `json:"auth_principal,omitempty"`
-	AdditionalProperties map[string]interface{}
+	AuthPrincipal *string `json:"auth_principal,omitempty"`
 }
-
-type enableLogExportRequest EnableLogExportRequest
 
 // NewEnableLogExportRequest instantiates a new EnableLogExportRequest object.
 // This constructor will assign default values to properties that have it defined,
@@ -96,29 +93,5 @@ func (o EnableLogExportRequest) MarshalJSON() ([]byte, error) {
 	if o.AuthPrincipal != nil {
 		toSerialize["auth_principal"] = o.AuthPrincipal
 	}
-
-	for key, value := range o.AdditionalProperties {
-		toSerialize[key] = value
-	}
-
 	return json.Marshal(toSerialize)
-}
-
-func (o *EnableLogExportRequest) UnmarshalJSON(bytes []byte) (err error) {
-	varEnableLogExportRequest := enableLogExportRequest{}
-
-	if err = json.Unmarshal(bytes, &varEnableLogExportRequest); err == nil {
-		*o = EnableLogExportRequest(varEnableLogExportRequest)
-	}
-
-	additionalProperties := make(map[string]interface{})
-
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
-		delete(additionalProperties, "type")
-		delete(additionalProperties, "log_name")
-		delete(additionalProperties, "auth_principal")
-		o.AdditionalProperties = additionalProperties
-	}
-
-	return err
 }

--- a/pkg/client/model_invoice.go
+++ b/pkg/client/model_invoice.go
@@ -36,11 +36,8 @@ type Invoice struct {
 	// InvoiceItems are sorted by the cluster name.
 	InvoiceItems []InvoiceItem `json:"invoice_items"`
 	// Balances are the amounts of currency left at the time of the invoice.
-	Balances             []CurrencyAmount `json:"balances"`
-	AdditionalProperties map[string]interface{}
+	Balances []CurrencyAmount `json:"balances"`
 }
-
-type invoice Invoice
 
 // NewInvoice instantiates a new Invoice object.
 // This constructor will assign default values to properties that have it defined,
@@ -175,32 +172,5 @@ func (o Invoice) MarshalJSON() ([]byte, error) {
 	if true {
 		toSerialize["balances"] = o.Balances
 	}
-
-	for key, value := range o.AdditionalProperties {
-		toSerialize[key] = value
-	}
-
 	return json.Marshal(toSerialize)
-}
-
-func (o *Invoice) UnmarshalJSON(bytes []byte) (err error) {
-	varInvoice := invoice{}
-
-	if err = json.Unmarshal(bytes, &varInvoice); err == nil {
-		*o = Invoice(varInvoice)
-	}
-
-	additionalProperties := make(map[string]interface{})
-
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
-		delete(additionalProperties, "invoice_id")
-		delete(additionalProperties, "totals")
-		delete(additionalProperties, "period_start")
-		delete(additionalProperties, "period_end")
-		delete(additionalProperties, "invoice_items")
-		delete(additionalProperties, "balances")
-		o.AdditionalProperties = additionalProperties
-	}
-
-	return err
 }

--- a/pkg/client/model_invoice_item.go
+++ b/pkg/client/model_invoice_item.go
@@ -28,11 +28,8 @@ type InvoiceItem struct {
 	// Totals is a list of the total amounts of line items per currency.
 	Totals []CurrencyAmount `json:"totals"`
 	// LineItems contain all the relevant line items from the Metronome invoice.
-	LineItems            []LineItem `json:"line_items"`
-	AdditionalProperties map[string]interface{}
+	LineItems []LineItem `json:"line_items"`
 }
-
-type invoiceItem InvoiceItem
 
 // NewInvoiceItem instantiates a new InvoiceItem object.
 // This constructor will assign default values to properties that have it defined,
@@ -110,29 +107,5 @@ func (o InvoiceItem) MarshalJSON() ([]byte, error) {
 	if true {
 		toSerialize["line_items"] = o.LineItems
 	}
-
-	for key, value := range o.AdditionalProperties {
-		toSerialize[key] = value
-	}
-
 	return json.Marshal(toSerialize)
-}
-
-func (o *InvoiceItem) UnmarshalJSON(bytes []byte) (err error) {
-	varInvoiceItem := invoiceItem{}
-
-	if err = json.Unmarshal(bytes, &varInvoiceItem); err == nil {
-		*o = InvoiceItem(varInvoiceItem)
-	}
-
-	additionalProperties := make(map[string]interface{})
-
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
-		delete(additionalProperties, "cluster")
-		delete(additionalProperties, "totals")
-		delete(additionalProperties, "line_items")
-		o.AdditionalProperties = additionalProperties
-	}
-
-	return err
 }

--- a/pkg/client/model_keyset_pagination_request.go
+++ b/pkg/client/model_keyset_pagination_request.go
@@ -25,14 +25,11 @@ import (
 
 // KeysetPaginationRequest struct for KeysetPaginationRequest.
 type KeysetPaginationRequest struct {
-	Page                 *string    `json:"page,omitempty"`
-	Limit                *int32     `json:"limit,omitempty"`
-	AsOfTime             *time.Time `json:"as_of_time,omitempty"`
-	SortOrder            *SortOrder `json:"sort_order,omitempty"`
-	AdditionalProperties map[string]interface{}
+	Page      *string    `json:"page,omitempty"`
+	Limit     *int32     `json:"limit,omitempty"`
+	AsOfTime  *time.Time `json:"as_of_time,omitempty"`
+	SortOrder *SortOrder `json:"sort_order,omitempty"`
 }
-
-type keysetPaginationRequest KeysetPaginationRequest
 
 // NewKeysetPaginationRequest instantiates a new KeysetPaginationRequest object.
 // This constructor will assign default values to properties that have it defined,
@@ -113,30 +110,5 @@ func (o KeysetPaginationRequest) MarshalJSON() ([]byte, error) {
 	if o.SortOrder != nil {
 		toSerialize["sort_order"] = o.SortOrder
 	}
-
-	for key, value := range o.AdditionalProperties {
-		toSerialize[key] = value
-	}
-
 	return json.Marshal(toSerialize)
-}
-
-func (o *KeysetPaginationRequest) UnmarshalJSON(bytes []byte) (err error) {
-	varKeysetPaginationRequest := keysetPaginationRequest{}
-
-	if err = json.Unmarshal(bytes, &varKeysetPaginationRequest); err == nil {
-		*o = KeysetPaginationRequest(varKeysetPaginationRequest)
-	}
-
-	additionalProperties := make(map[string]interface{})
-
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
-		delete(additionalProperties, "page")
-		delete(additionalProperties, "limit")
-		delete(additionalProperties, "as_of_time")
-		delete(additionalProperties, "sort_order")
-		o.AdditionalProperties = additionalProperties
-	}
-
-	return err
 }

--- a/pkg/client/model_keyset_pagination_response.go
+++ b/pkg/client/model_keyset_pagination_response.go
@@ -24,12 +24,9 @@ import (
 
 // KeysetPaginationResponse struct for KeysetPaginationResponse.
 type KeysetPaginationResponse struct {
-	NextPage             *string `json:"next_page,omitempty"`
-	PreviousPage         *string `json:"previous_page,omitempty"`
-	AdditionalProperties map[string]interface{}
+	NextPage     *string `json:"next_page,omitempty"`
+	PreviousPage *string `json:"previous_page,omitempty"`
 }
-
-type keysetPaginationResponse KeysetPaginationResponse
 
 // NewKeysetPaginationResponse instantiates a new KeysetPaginationResponse object.
 // This constructor will assign default values to properties that have it defined,
@@ -76,28 +73,5 @@ func (o KeysetPaginationResponse) MarshalJSON() ([]byte, error) {
 	if o.PreviousPage != nil {
 		toSerialize["previous_page"] = o.PreviousPage
 	}
-
-	for key, value := range o.AdditionalProperties {
-		toSerialize[key] = value
-	}
-
 	return json.Marshal(toSerialize)
-}
-
-func (o *KeysetPaginationResponse) UnmarshalJSON(bytes []byte) (err error) {
-	varKeysetPaginationResponse := keysetPaginationResponse{}
-
-	if err = json.Unmarshal(bytes, &varKeysetPaginationResponse); err == nil {
-		*o = KeysetPaginationResponse(varKeysetPaginationResponse)
-	}
-
-	additionalProperties := make(map[string]interface{})
-
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
-		delete(additionalProperties, "next_page")
-		delete(additionalProperties, "previous_page")
-		o.AdditionalProperties = additionalProperties
-	}
-
-	return err
 }

--- a/pkg/client/model_line_item.go
+++ b/pkg/client/model_line_item.go
@@ -29,13 +29,10 @@ type LineItem struct {
 	// Quantity is the number of the specific line items used.
 	Quantity float64 `json:"quantity"`
 	// UnitCost is the cost per unit of line item.
-	UnitCost             float64          `json:"unit_cost"`
-	Total                CurrencyAmount   `json:"total"`
-	QuantityUnit         QuantityUnitType `json:"quantity_unit"`
-	AdditionalProperties map[string]interface{}
+	UnitCost     float64          `json:"unit_cost"`
+	Total        CurrencyAmount   `json:"total"`
+	QuantityUnit QuantityUnitType `json:"quantity_unit"`
 }
-
-type lineItem LineItem
 
 // NewLineItem instantiates a new LineItem object.
 // This constructor will assign default values to properties that have it defined,
@@ -151,31 +148,5 @@ func (o LineItem) MarshalJSON() ([]byte, error) {
 	if true {
 		toSerialize["quantity_unit"] = o.QuantityUnit
 	}
-
-	for key, value := range o.AdditionalProperties {
-		toSerialize[key] = value
-	}
-
 	return json.Marshal(toSerialize)
-}
-
-func (o *LineItem) UnmarshalJSON(bytes []byte) (err error) {
-	varLineItem := lineItem{}
-
-	if err = json.Unmarshal(bytes, &varLineItem); err == nil {
-		*o = LineItem(varLineItem)
-	}
-
-	additionalProperties := make(map[string]interface{})
-
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
-		delete(additionalProperties, "description")
-		delete(additionalProperties, "quantity")
-		delete(additionalProperties, "unit_cost")
-		delete(additionalProperties, "total")
-		delete(additionalProperties, "quantity_unit")
-		o.AdditionalProperties = additionalProperties
-	}
-
-	return err
 }

--- a/pkg/client/model_list_allowlist_entries_response.go
+++ b/pkg/client/model_list_allowlist_entries_response.go
@@ -24,13 +24,10 @@ import (
 
 // ListAllowlistEntriesResponse struct for ListAllowlistEntriesResponse.
 type ListAllowlistEntriesResponse struct {
-	Allowlist            []AllowlistEntry          `json:"allowlist"`
-	Propagating          bool                      `json:"propagating"`
-	Pagination           *KeysetPaginationResponse `json:"pagination,omitempty"`
-	AdditionalProperties map[string]interface{}
+	Allowlist   []AllowlistEntry          `json:"allowlist"`
+	Propagating bool                      `json:"propagating"`
+	Pagination  *KeysetPaginationResponse `json:"pagination,omitempty"`
 }
-
-type listAllowlistEntriesResponse ListAllowlistEntriesResponse
 
 // NewListAllowlistEntriesResponse instantiates a new ListAllowlistEntriesResponse object.
 // This constructor will assign default values to properties that have it defined,
@@ -106,29 +103,5 @@ func (o ListAllowlistEntriesResponse) MarshalJSON() ([]byte, error) {
 	if o.Pagination != nil {
 		toSerialize["pagination"] = o.Pagination
 	}
-
-	for key, value := range o.AdditionalProperties {
-		toSerialize[key] = value
-	}
-
 	return json.Marshal(toSerialize)
-}
-
-func (o *ListAllowlistEntriesResponse) UnmarshalJSON(bytes []byte) (err error) {
-	varListAllowlistEntriesResponse := listAllowlistEntriesResponse{}
-
-	if err = json.Unmarshal(bytes, &varListAllowlistEntriesResponse); err == nil {
-		*o = ListAllowlistEntriesResponse(varListAllowlistEntriesResponse)
-	}
-
-	additionalProperties := make(map[string]interface{})
-
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
-		delete(additionalProperties, "allowlist")
-		delete(additionalProperties, "propagating")
-		delete(additionalProperties, "pagination")
-		o.AdditionalProperties = additionalProperties
-	}
-
-	return err
 }

--- a/pkg/client/model_list_available_regions_response.go
+++ b/pkg/client/model_list_available_regions_response.go
@@ -24,12 +24,9 @@ import (
 
 // ListAvailableRegionsResponse struct for ListAvailableRegionsResponse.
 type ListAvailableRegionsResponse struct {
-	Regions              []CloudProviderRegion     `json:"regions"`
-	Pagination           *KeysetPaginationResponse `json:"pagination,omitempty"`
-	AdditionalProperties map[string]interface{}
+	Regions    []CloudProviderRegion     `json:"regions"`
+	Pagination *KeysetPaginationResponse `json:"pagination,omitempty"`
 }
-
-type listAvailableRegionsResponse ListAvailableRegionsResponse
 
 // NewListAvailableRegionsResponse instantiates a new ListAvailableRegionsResponse object.
 // This constructor will assign default values to properties that have it defined,
@@ -86,28 +83,5 @@ func (o ListAvailableRegionsResponse) MarshalJSON() ([]byte, error) {
 	if o.Pagination != nil {
 		toSerialize["pagination"] = o.Pagination
 	}
-
-	for key, value := range o.AdditionalProperties {
-		toSerialize[key] = value
-	}
-
 	return json.Marshal(toSerialize)
-}
-
-func (o *ListAvailableRegionsResponse) UnmarshalJSON(bytes []byte) (err error) {
-	varListAvailableRegionsResponse := listAvailableRegionsResponse{}
-
-	if err = json.Unmarshal(bytes, &varListAvailableRegionsResponse); err == nil {
-		*o = ListAvailableRegionsResponse(varListAvailableRegionsResponse)
-	}
-
-	additionalProperties := make(map[string]interface{})
-
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
-		delete(additionalProperties, "regions")
-		delete(additionalProperties, "pagination")
-		o.AdditionalProperties = additionalProperties
-	}
-
-	return err
 }

--- a/pkg/client/model_list_cluster_nodes_response.go
+++ b/pkg/client/model_list_cluster_nodes_response.go
@@ -24,12 +24,9 @@ import (
 
 // ListClusterNodesResponse struct for ListClusterNodesResponse.
 type ListClusterNodesResponse struct {
-	Nodes                []Node                    `json:"nodes"`
-	Pagination           *KeysetPaginationResponse `json:"pagination,omitempty"`
-	AdditionalProperties map[string]interface{}
+	Nodes      []Node                    `json:"nodes"`
+	Pagination *KeysetPaginationResponse `json:"pagination,omitempty"`
 }
-
-type listClusterNodesResponse ListClusterNodesResponse
 
 // NewListClusterNodesResponse instantiates a new ListClusterNodesResponse object.
 // This constructor will assign default values to properties that have it defined,
@@ -86,28 +83,5 @@ func (o ListClusterNodesResponse) MarshalJSON() ([]byte, error) {
 	if o.Pagination != nil {
 		toSerialize["pagination"] = o.Pagination
 	}
-
-	for key, value := range o.AdditionalProperties {
-		toSerialize[key] = value
-	}
-
 	return json.Marshal(toSerialize)
-}
-
-func (o *ListClusterNodesResponse) UnmarshalJSON(bytes []byte) (err error) {
-	varListClusterNodesResponse := listClusterNodesResponse{}
-
-	if err = json.Unmarshal(bytes, &varListClusterNodesResponse); err == nil {
-		*o = ListClusterNodesResponse(varListClusterNodesResponse)
-	}
-
-	additionalProperties := make(map[string]interface{})
-
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
-		delete(additionalProperties, "nodes")
-		delete(additionalProperties, "pagination")
-		o.AdditionalProperties = additionalProperties
-	}
-
-	return err
 }

--- a/pkg/client/model_list_clusters_response.go
+++ b/pkg/client/model_list_clusters_response.go
@@ -24,12 +24,9 @@ import (
 
 // ListClustersResponse struct for ListClustersResponse.
 type ListClustersResponse struct {
-	Clusters             []Cluster                 `json:"clusters"`
-	Pagination           *KeysetPaginationResponse `json:"pagination,omitempty"`
-	AdditionalProperties map[string]interface{}
+	Clusters   []Cluster                 `json:"clusters"`
+	Pagination *KeysetPaginationResponse `json:"pagination,omitempty"`
 }
-
-type listClustersResponse ListClustersResponse
 
 // NewListClustersResponse instantiates a new ListClustersResponse object.
 // This constructor will assign default values to properties that have it defined,
@@ -86,28 +83,5 @@ func (o ListClustersResponse) MarshalJSON() ([]byte, error) {
 	if o.Pagination != nil {
 		toSerialize["pagination"] = o.Pagination
 	}
-
-	for key, value := range o.AdditionalProperties {
-		toSerialize[key] = value
-	}
-
 	return json.Marshal(toSerialize)
-}
-
-func (o *ListClustersResponse) UnmarshalJSON(bytes []byte) (err error) {
-	varListClustersResponse := listClustersResponse{}
-
-	if err = json.Unmarshal(bytes, &varListClustersResponse); err == nil {
-		*o = ListClustersResponse(varListClustersResponse)
-	}
-
-	additionalProperties := make(map[string]interface{})
-
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
-		delete(additionalProperties, "clusters")
-		delete(additionalProperties, "pagination")
-		o.AdditionalProperties = additionalProperties
-	}
-
-	return err
 }

--- a/pkg/client/model_list_invoices_response.go
+++ b/pkg/client/model_list_invoices_response.go
@@ -25,11 +25,8 @@ import (
 // ListInvoicesResponse struct for ListInvoicesResponse.
 type ListInvoicesResponse struct {
 	// Invoices are sorted by PeriodStart time.
-	Invoices             []Invoice `json:"invoices"`
-	AdditionalProperties map[string]interface{}
+	Invoices []Invoice `json:"invoices"`
 }
-
-type listInvoicesResponse ListInvoicesResponse
 
 // NewListInvoicesResponse instantiates a new ListInvoicesResponse object.
 // This constructor will assign default values to properties that have it defined,
@@ -69,27 +66,5 @@ func (o ListInvoicesResponse) MarshalJSON() ([]byte, error) {
 	if true {
 		toSerialize["invoices"] = o.Invoices
 	}
-
-	for key, value := range o.AdditionalProperties {
-		toSerialize[key] = value
-	}
-
 	return json.Marshal(toSerialize)
-}
-
-func (o *ListInvoicesResponse) UnmarshalJSON(bytes []byte) (err error) {
-	varListInvoicesResponse := listInvoicesResponse{}
-
-	if err = json.Unmarshal(bytes, &varListInvoicesResponse); err == nil {
-		*o = ListInvoicesResponse(varListInvoicesResponse)
-	}
-
-	additionalProperties := make(map[string]interface{})
-
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
-		delete(additionalProperties, "invoices")
-		o.AdditionalProperties = additionalProperties
-	}
-
-	return err
 }

--- a/pkg/client/model_list_sql_users_response.go
+++ b/pkg/client/model_list_sql_users_response.go
@@ -24,12 +24,9 @@ import (
 
 // ListSQLUsersResponse struct for ListSQLUsersResponse.
 type ListSQLUsersResponse struct {
-	Users                []SQLUser                 `json:"users"`
-	Pagination           *KeysetPaginationResponse `json:"pagination,omitempty"`
-	AdditionalProperties map[string]interface{}
+	Users      []SQLUser                 `json:"users"`
+	Pagination *KeysetPaginationResponse `json:"pagination,omitempty"`
 }
-
-type listSQLUsersResponse ListSQLUsersResponse
 
 // NewListSQLUsersResponse instantiates a new ListSQLUsersResponse object.
 // This constructor will assign default values to properties that have it defined,
@@ -86,28 +83,5 @@ func (o ListSQLUsersResponse) MarshalJSON() ([]byte, error) {
 	if o.Pagination != nil {
 		toSerialize["pagination"] = o.Pagination
 	}
-
-	for key, value := range o.AdditionalProperties {
-		toSerialize[key] = value
-	}
-
 	return json.Marshal(toSerialize)
-}
-
-func (o *ListSQLUsersResponse) UnmarshalJSON(bytes []byte) (err error) {
-	varListSQLUsersResponse := listSQLUsersResponse{}
-
-	if err = json.Unmarshal(bytes, &varListSQLUsersResponse); err == nil {
-		*o = ListSQLUsersResponse(varListSQLUsersResponse)
-	}
-
-	additionalProperties := make(map[string]interface{})
-
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
-		delete(additionalProperties, "users")
-		delete(additionalProperties, "pagination")
-		o.AdditionalProperties = additionalProperties
-	}
-
-	return err
 }

--- a/pkg/client/model_log_export_cluster_info.go
+++ b/pkg/client/model_log_export_cluster_info.go
@@ -25,16 +25,13 @@ import (
 
 // LogExportClusterInfo LogExportClusterInfo contains a package of information that fully describes both the intended state of the log export configuration for a specific cluster but also some metadata around its deployment status, any error messages, and some timestamps..
 type LogExportClusterInfo struct {
-	ClusterId            *string                        `json:"cluster_id,omitempty"`
-	Status               *LogExportStatus               `json:"status,omitempty"`
-	UserMessage          *string                        `json:"user_message,omitempty"`
-	Spec                 *LogExportClusterSpecification `json:"spec,omitempty"`
-	CreatedAt            *time.Time                     `json:"created_at,omitempty"`
-	UpdatedAt            *time.Time                     `json:"updated_at,omitempty"`
-	AdditionalProperties map[string]interface{}
+	ClusterId   *string                        `json:"cluster_id,omitempty"`
+	Status      *LogExportStatus               `json:"status,omitempty"`
+	UserMessage *string                        `json:"user_message,omitempty"`
+	Spec        *LogExportClusterSpecification `json:"spec,omitempty"`
+	CreatedAt   *time.Time                     `json:"created_at,omitempty"`
+	UpdatedAt   *time.Time                     `json:"updated_at,omitempty"`
 }
-
-type logExportClusterInfo LogExportClusterInfo
 
 // NewLogExportClusterInfo instantiates a new LogExportClusterInfo object.
 // This constructor will assign default values to properties that have it defined,
@@ -149,32 +146,5 @@ func (o LogExportClusterInfo) MarshalJSON() ([]byte, error) {
 	if o.UpdatedAt != nil {
 		toSerialize["updated_at"] = o.UpdatedAt
 	}
-
-	for key, value := range o.AdditionalProperties {
-		toSerialize[key] = value
-	}
-
 	return json.Marshal(toSerialize)
-}
-
-func (o *LogExportClusterInfo) UnmarshalJSON(bytes []byte) (err error) {
-	varLogExportClusterInfo := logExportClusterInfo{}
-
-	if err = json.Unmarshal(bytes, &varLogExportClusterInfo); err == nil {
-		*o = LogExportClusterInfo(varLogExportClusterInfo)
-	}
-
-	additionalProperties := make(map[string]interface{})
-
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
-		delete(additionalProperties, "cluster_id")
-		delete(additionalProperties, "status")
-		delete(additionalProperties, "user_message")
-		delete(additionalProperties, "spec")
-		delete(additionalProperties, "created_at")
-		delete(additionalProperties, "updated_at")
-		o.AdditionalProperties = additionalProperties
-	}
-
-	return err
 }

--- a/pkg/client/model_log_export_cluster_specification.go
+++ b/pkg/client/model_log_export_cluster_specification.go
@@ -28,11 +28,8 @@ type LogExportClusterSpecification struct {
 	// log_name is an identifier for the logs in the customer's log sink.
 	LogName *string `json:"log_name,omitempty"`
 	// auth_principal is either the AWS Role ARN that identifies a role that the cluster account can assume to write to CloudWatch or the GCP Project ID that the cluster service account has permissions to write to for cloud logging.
-	AuthPrincipal        *string `json:"auth_principal,omitempty"`
-	AdditionalProperties map[string]interface{}
+	AuthPrincipal *string `json:"auth_principal,omitempty"`
 }
-
-type logExportClusterSpecification LogExportClusterSpecification
 
 // NewLogExportClusterSpecification instantiates a new LogExportClusterSpecification object.
 // This constructor will assign default values to properties that have it defined,
@@ -96,29 +93,5 @@ func (o LogExportClusterSpecification) MarshalJSON() ([]byte, error) {
 	if o.AuthPrincipal != nil {
 		toSerialize["auth_principal"] = o.AuthPrincipal
 	}
-
-	for key, value := range o.AdditionalProperties {
-		toSerialize[key] = value
-	}
-
 	return json.Marshal(toSerialize)
-}
-
-func (o *LogExportClusterSpecification) UnmarshalJSON(bytes []byte) (err error) {
-	varLogExportClusterSpecification := logExportClusterSpecification{}
-
-	if err = json.Unmarshal(bytes, &varLogExportClusterSpecification); err == nil {
-		*o = LogExportClusterSpecification(varLogExportClusterSpecification)
-	}
-
-	additionalProperties := make(map[string]interface{})
-
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
-		delete(additionalProperties, "type")
-		delete(additionalProperties, "log_name")
-		delete(additionalProperties, "auth_principal")
-		o.AdditionalProperties = additionalProperties
-	}
-
-	return err
 }

--- a/pkg/client/model_node.go
+++ b/pkg/client/model_node.go
@@ -24,13 +24,10 @@ import (
 
 // Node struct for Node.
 type Node struct {
-	Name                 string     `json:"name"`
-	RegionName           string     `json:"region_name"`
-	Status               NodeStatus `json:"status"`
-	AdditionalProperties map[string]interface{}
+	Name       string     `json:"name"`
+	RegionName string     `json:"region_name"`
+	Status     NodeStatus `json:"status"`
 }
-
-type node Node
 
 // NewNode instantiates a new Node object.
 // This constructor will assign default values to properties that have it defined,
@@ -108,29 +105,5 @@ func (o Node) MarshalJSON() ([]byte, error) {
 	if true {
 		toSerialize["status"] = o.Status
 	}
-
-	for key, value := range o.AdditionalProperties {
-		toSerialize[key] = value
-	}
-
 	return json.Marshal(toSerialize)
-}
-
-func (o *Node) UnmarshalJSON(bytes []byte) (err error) {
-	varNode := node{}
-
-	if err = json.Unmarshal(bytes, &varNode); err == nil {
-		*o = Node(varNode)
-	}
-
-	additionalProperties := make(map[string]interface{})
-
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
-		delete(additionalProperties, "name")
-		delete(additionalProperties, "region_name")
-		delete(additionalProperties, "status")
-		o.AdditionalProperties = additionalProperties
-	}
-
-	return err
 }

--- a/pkg/client/model_private_endpoint_service.go
+++ b/pkg/client/model_private_endpoint_service.go
@@ -25,14 +25,11 @@ import (
 // PrivateEndpointService struct for PrivateEndpointService.
 type PrivateEndpointService struct {
 	// RegionName is the cloud provider region name (i.e. us-east-1).
-	RegionName           string                       `json:"region_name"`
-	CloudProvider        ApiCloudProvider             `json:"cloud_provider"`
-	Status               PrivateEndpointServiceStatus `json:"status"`
-	Aws                  AWSPrivateLinkServiceDetail  `json:"aws"`
-	AdditionalProperties map[string]interface{}
+	RegionName    string                       `json:"region_name"`
+	CloudProvider ApiCloudProvider             `json:"cloud_provider"`
+	Status        PrivateEndpointServiceStatus `json:"status"`
+	Aws           AWSPrivateLinkServiceDetail  `json:"aws"`
 }
-
-type privateEndpointService PrivateEndpointService
 
 // NewPrivateEndpointService instantiates a new PrivateEndpointService object.
 // This constructor will assign default values to properties that have it defined,
@@ -129,30 +126,5 @@ func (o PrivateEndpointService) MarshalJSON() ([]byte, error) {
 	if true {
 		toSerialize["aws"] = o.Aws
 	}
-
-	for key, value := range o.AdditionalProperties {
-		toSerialize[key] = value
-	}
-
 	return json.Marshal(toSerialize)
-}
-
-func (o *PrivateEndpointService) UnmarshalJSON(bytes []byte) (err error) {
-	varPrivateEndpointService := privateEndpointService{}
-
-	if err = json.Unmarshal(bytes, &varPrivateEndpointService); err == nil {
-		*o = PrivateEndpointService(varPrivateEndpointService)
-	}
-
-	additionalProperties := make(map[string]interface{})
-
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
-		delete(additionalProperties, "region_name")
-		delete(additionalProperties, "cloud_provider")
-		delete(additionalProperties, "status")
-		delete(additionalProperties, "aws")
-		o.AdditionalProperties = additionalProperties
-	}
-
-	return err
 }

--- a/pkg/client/model_private_endpoint_services.go
+++ b/pkg/client/model_private_endpoint_services.go
@@ -25,11 +25,8 @@ import (
 // PrivateEndpointServices struct for PrivateEndpointServices.
 type PrivateEndpointServices struct {
 	// Services contains a list of all cluster related services.
-	Services             []PrivateEndpointService `json:"services"`
-	AdditionalProperties map[string]interface{}
+	Services []PrivateEndpointService `json:"services"`
 }
-
-type privateEndpointServices PrivateEndpointServices
 
 // NewPrivateEndpointServices instantiates a new PrivateEndpointServices object.
 // This constructor will assign default values to properties that have it defined,
@@ -69,27 +66,5 @@ func (o PrivateEndpointServices) MarshalJSON() ([]byte, error) {
 	if true {
 		toSerialize["services"] = o.Services
 	}
-
-	for key, value := range o.AdditionalProperties {
-		toSerialize[key] = value
-	}
-
 	return json.Marshal(toSerialize)
-}
-
-func (o *PrivateEndpointServices) UnmarshalJSON(bytes []byte) (err error) {
-	varPrivateEndpointServices := privateEndpointServices{}
-
-	if err = json.Unmarshal(bytes, &varPrivateEndpointServices); err == nil {
-		*o = PrivateEndpointServices(varPrivateEndpointServices)
-	}
-
-	additionalProperties := make(map[string]interface{})
-
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
-		delete(additionalProperties, "services")
-		o.AdditionalProperties = additionalProperties
-	}
-
-	return err
 }

--- a/pkg/client/model_region.go
+++ b/pkg/client/model_region.go
@@ -28,11 +28,8 @@ type Region struct {
 	SqlDns string `json:"sql_dns"`
 	UiDns  string `json:"ui_dns"`
 	// NodeCount will be 0 for serverless clusters.
-	NodeCount            int32 `json:"node_count"`
-	AdditionalProperties map[string]interface{}
+	NodeCount int32 `json:"node_count"`
 }
-
-type region Region
 
 // NewRegion instantiates a new Region object.
 // This constructor will assign default values to properties that have it defined,
@@ -129,30 +126,5 @@ func (o Region) MarshalJSON() ([]byte, error) {
 	if true {
 		toSerialize["node_count"] = o.NodeCount
 	}
-
-	for key, value := range o.AdditionalProperties {
-		toSerialize[key] = value
-	}
-
 	return json.Marshal(toSerialize)
-}
-
-func (o *Region) UnmarshalJSON(bytes []byte) (err error) {
-	varRegion := region{}
-
-	if err = json.Unmarshal(bytes, &varRegion); err == nil {
-		*o = Region(varRegion)
-	}
-
-	additionalProperties := make(map[string]interface{})
-
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
-		delete(additionalProperties, "name")
-		delete(additionalProperties, "sql_dns")
-		delete(additionalProperties, "ui_dns")
-		delete(additionalProperties, "node_count")
-		o.AdditionalProperties = additionalProperties
-	}
-
-	return err
 }

--- a/pkg/client/model_serverless_cluster_config.go
+++ b/pkg/client/model_serverless_cluster_config.go
@@ -27,11 +27,8 @@ type ServerlessClusterConfig struct {
 	// Spend limit in US cents.
 	SpendLimit int32 `json:"spend_limit"`
 	// Used to build a connection string.
-	RoutingId            string `json:"routing_id"`
-	AdditionalProperties map[string]interface{}
+	RoutingId string `json:"routing_id"`
 }
-
-type serverlessClusterConfig ServerlessClusterConfig
 
 // NewServerlessClusterConfig instantiates a new ServerlessClusterConfig object.
 // This constructor will assign default values to properties that have it defined,
@@ -90,28 +87,5 @@ func (o ServerlessClusterConfig) MarshalJSON() ([]byte, error) {
 	if true {
 		toSerialize["routing_id"] = o.RoutingId
 	}
-
-	for key, value := range o.AdditionalProperties {
-		toSerialize[key] = value
-	}
-
 	return json.Marshal(toSerialize)
-}
-
-func (o *ServerlessClusterConfig) UnmarshalJSON(bytes []byte) (err error) {
-	varServerlessClusterConfig := serverlessClusterConfig{}
-
-	if err = json.Unmarshal(bytes, &varServerlessClusterConfig); err == nil {
-		*o = ServerlessClusterConfig(varServerlessClusterConfig)
-	}
-
-	additionalProperties := make(map[string]interface{})
-
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
-		delete(additionalProperties, "spend_limit")
-		delete(additionalProperties, "routing_id")
-		o.AdditionalProperties = additionalProperties
-	}
-
-	return err
 }

--- a/pkg/client/model_serverless_cluster_create_specification.go
+++ b/pkg/client/model_serverless_cluster_create_specification.go
@@ -25,12 +25,9 @@ import (
 // ServerlessClusterCreateSpecification struct for ServerlessClusterCreateSpecification.
 type ServerlessClusterCreateSpecification struct {
 	// Region values should match the cloud provider's zone code. For example, for Oregon, set region_name to \"us-west2\" for GCP and \"us-west-2\" for AWS.
-	Regions              []string `json:"regions"`
-	SpendLimit           int32    `json:"spend_limit"`
-	AdditionalProperties map[string]interface{}
+	Regions    []string `json:"regions"`
+	SpendLimit int32    `json:"spend_limit"`
 }
-
-type serverlessClusterCreateSpecification ServerlessClusterCreateSpecification
 
 // NewServerlessClusterCreateSpecification instantiates a new ServerlessClusterCreateSpecification object.
 // This constructor will assign default values to properties that have it defined,
@@ -89,28 +86,5 @@ func (o ServerlessClusterCreateSpecification) MarshalJSON() ([]byte, error) {
 	if true {
 		toSerialize["spend_limit"] = o.SpendLimit
 	}
-
-	for key, value := range o.AdditionalProperties {
-		toSerialize[key] = value
-	}
-
 	return json.Marshal(toSerialize)
-}
-
-func (o *ServerlessClusterCreateSpecification) UnmarshalJSON(bytes []byte) (err error) {
-	varServerlessClusterCreateSpecification := serverlessClusterCreateSpecification{}
-
-	if err = json.Unmarshal(bytes, &varServerlessClusterCreateSpecification); err == nil {
-		*o = ServerlessClusterCreateSpecification(varServerlessClusterCreateSpecification)
-	}
-
-	additionalProperties := make(map[string]interface{})
-
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
-		delete(additionalProperties, "regions")
-		delete(additionalProperties, "spend_limit")
-		o.AdditionalProperties = additionalProperties
-	}
-
-	return err
 }

--- a/pkg/client/model_serverless_cluster_update_specification.go
+++ b/pkg/client/model_serverless_cluster_update_specification.go
@@ -24,11 +24,8 @@ import (
 
 // ServerlessClusterUpdateSpecification struct for ServerlessClusterUpdateSpecification.
 type ServerlessClusterUpdateSpecification struct {
-	SpendLimit           int32 `json:"spend_limit"`
-	AdditionalProperties map[string]interface{}
+	SpendLimit int32 `json:"spend_limit"`
 }
-
-type serverlessClusterUpdateSpecification ServerlessClusterUpdateSpecification
 
 // NewServerlessClusterUpdateSpecification instantiates a new ServerlessClusterUpdateSpecification object.
 // This constructor will assign default values to properties that have it defined,
@@ -68,27 +65,5 @@ func (o ServerlessClusterUpdateSpecification) MarshalJSON() ([]byte, error) {
 	if true {
 		toSerialize["spend_limit"] = o.SpendLimit
 	}
-
-	for key, value := range o.AdditionalProperties {
-		toSerialize[key] = value
-	}
-
 	return json.Marshal(toSerialize)
-}
-
-func (o *ServerlessClusterUpdateSpecification) UnmarshalJSON(bytes []byte) (err error) {
-	varServerlessClusterUpdateSpecification := serverlessClusterUpdateSpecification{}
-
-	if err = json.Unmarshal(bytes, &varServerlessClusterUpdateSpecification); err == nil {
-		*o = ServerlessClusterUpdateSpecification(varServerlessClusterUpdateSpecification)
-	}
-
-	additionalProperties := make(map[string]interface{})
-
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
-		delete(additionalProperties, "spend_limit")
-		o.AdditionalProperties = additionalProperties
-	}
-
-	return err
 }

--- a/pkg/client/model_sql_user.go
+++ b/pkg/client/model_sql_user.go
@@ -24,11 +24,8 @@ import (
 
 // SQLUser struct for SQLUser.
 type SQLUser struct {
-	Name                 string `json:"name"`
-	AdditionalProperties map[string]interface{}
+	Name string `json:"name"`
 }
-
-type sQLUser SQLUser
 
 // NewSQLUser instantiates a new SQLUser object.
 // This constructor will assign default values to properties that have it defined,
@@ -68,27 +65,5 @@ func (o SQLUser) MarshalJSON() ([]byte, error) {
 	if true {
 		toSerialize["name"] = o.Name
 	}
-
-	for key, value := range o.AdditionalProperties {
-		toSerialize[key] = value
-	}
-
 	return json.Marshal(toSerialize)
-}
-
-func (o *SQLUser) UnmarshalJSON(bytes []byte) (err error) {
-	varSQLUser := sQLUser{}
-
-	if err = json.Unmarshal(bytes, &varSQLUser); err == nil {
-		*o = SQLUser(varSQLUser)
-	}
-
-	additionalProperties := make(map[string]interface{})
-
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
-		delete(additionalProperties, "name")
-		o.AdditionalProperties = additionalProperties
-	}
-
-	return err
 }

--- a/pkg/client/model_status.go
+++ b/pkg/client/model_status.go
@@ -24,13 +24,10 @@ import (
 
 // Status struct for Status.
 type Status struct {
-	Code                 *int32  `json:"code,omitempty"`
-	Message              *string `json:"message,omitempty"`
-	Details              *[]Any  `json:"details,omitempty"`
-	AdditionalProperties map[string]interface{}
+	Code    *int32  `json:"code,omitempty"`
+	Message *string `json:"message,omitempty"`
+	Details *[]Any  `json:"details,omitempty"`
 }
-
-type status Status
 
 // NewStatus instantiates a new Status object.
 // This constructor will assign default values to properties that have it defined,
@@ -94,29 +91,5 @@ func (o Status) MarshalJSON() ([]byte, error) {
 	if o.Details != nil {
 		toSerialize["details"] = o.Details
 	}
-
-	for key, value := range o.AdditionalProperties {
-		toSerialize[key] = value
-	}
-
 	return json.Marshal(toSerialize)
-}
-
-func (o *Status) UnmarshalJSON(bytes []byte) (err error) {
-	varStatus := status{}
-
-	if err = json.Unmarshal(bytes, &varStatus); err == nil {
-		*o = Status(varStatus)
-	}
-
-	additionalProperties := make(map[string]interface{})
-
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
-		delete(additionalProperties, "code")
-		delete(additionalProperties, "message")
-		delete(additionalProperties, "details")
-		o.AdditionalProperties = additionalProperties
-	}
-
-	return err
 }

--- a/pkg/client/model_update_cluster_specification.go
+++ b/pkg/client/model_update_cluster_specification.go
@@ -24,12 +24,9 @@ import (
 
 // UpdateClusterSpecification struct for UpdateClusterSpecification.
 type UpdateClusterSpecification struct {
-	Dedicated            *DedicatedClusterUpdateSpecification  `json:"dedicated,omitempty"`
-	Serverless           *ServerlessClusterUpdateSpecification `json:"serverless,omitempty"`
-	AdditionalProperties map[string]interface{}
+	Dedicated  *DedicatedClusterUpdateSpecification  `json:"dedicated,omitempty"`
+	Serverless *ServerlessClusterUpdateSpecification `json:"serverless,omitempty"`
 }
-
-type updateClusterSpecification UpdateClusterSpecification
 
 // NewUpdateClusterSpecification instantiates a new UpdateClusterSpecification object.
 // This constructor will assign default values to properties that have it defined,
@@ -76,28 +73,5 @@ func (o UpdateClusterSpecification) MarshalJSON() ([]byte, error) {
 	if o.Serverless != nil {
 		toSerialize["serverless"] = o.Serverless
 	}
-
-	for key, value := range o.AdditionalProperties {
-		toSerialize[key] = value
-	}
-
 	return json.Marshal(toSerialize)
-}
-
-func (o *UpdateClusterSpecification) UnmarshalJSON(bytes []byte) (err error) {
-	varUpdateClusterSpecification := updateClusterSpecification{}
-
-	if err = json.Unmarshal(bytes, &varUpdateClusterSpecification); err == nil {
-		*o = UpdateClusterSpecification(varUpdateClusterSpecification)
-	}
-
-	additionalProperties := make(map[string]interface{})
-
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
-		delete(additionalProperties, "dedicated")
-		delete(additionalProperties, "serverless")
-		o.AdditionalProperties = additionalProperties
-	}
-
-	return err
 }

--- a/pkg/client/model_update_cmek_status_request.go
+++ b/pkg/client/model_update_cmek_status_request.go
@@ -24,11 +24,8 @@ import (
 
 // UpdateCMEKStatusRequest struct for UpdateCMEKStatusRequest.
 type UpdateCMEKStatusRequest struct {
-	Action               CMEKCustomerAction `json:"action"`
-	AdditionalProperties map[string]interface{}
+	Action CMEKCustomerAction `json:"action"`
 }
-
-type updateCMEKStatusRequest UpdateCMEKStatusRequest
 
 // NewUpdateCMEKStatusRequest instantiates a new UpdateCMEKStatusRequest object.
 // This constructor will assign default values to properties that have it defined,
@@ -68,27 +65,5 @@ func (o UpdateCMEKStatusRequest) MarshalJSON() ([]byte, error) {
 	if true {
 		toSerialize["action"] = o.Action
 	}
-
-	for key, value := range o.AdditionalProperties {
-		toSerialize[key] = value
-	}
-
 	return json.Marshal(toSerialize)
-}
-
-func (o *UpdateCMEKStatusRequest) UnmarshalJSON(bytes []byte) (err error) {
-	varUpdateCMEKStatusRequest := updateCMEKStatusRequest{}
-
-	if err = json.Unmarshal(bytes, &varUpdateCMEKStatusRequest); err == nil {
-		*o = UpdateCMEKStatusRequest(varUpdateCMEKStatusRequest)
-	}
-
-	additionalProperties := make(map[string]interface{})
-
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
-		delete(additionalProperties, "action")
-		o.AdditionalProperties = additionalProperties
-	}
-
-	return err
 }

--- a/pkg/client/model_update_database_request.go
+++ b/pkg/client/model_update_database_request.go
@@ -24,12 +24,9 @@ import (
 
 // UpdateDatabaseRequest struct for UpdateDatabaseRequest.
 type UpdateDatabaseRequest struct {
-	Name                 string `json:"name"`
-	NewName              string `json:"new_name"`
-	AdditionalProperties map[string]interface{}
+	Name    string `json:"name"`
+	NewName string `json:"new_name"`
 }
-
-type updateDatabaseRequest UpdateDatabaseRequest
 
 // NewUpdateDatabaseRequest instantiates a new UpdateDatabaseRequest object.
 // This constructor will assign default values to properties that have it defined,
@@ -88,28 +85,5 @@ func (o UpdateDatabaseRequest) MarshalJSON() ([]byte, error) {
 	if true {
 		toSerialize["new_name"] = o.NewName
 	}
-
-	for key, value := range o.AdditionalProperties {
-		toSerialize[key] = value
-	}
-
 	return json.Marshal(toSerialize)
-}
-
-func (o *UpdateDatabaseRequest) UnmarshalJSON(bytes []byte) (err error) {
-	varUpdateDatabaseRequest := updateDatabaseRequest{}
-
-	if err = json.Unmarshal(bytes, &varUpdateDatabaseRequest); err == nil {
-		*o = UpdateDatabaseRequest(varUpdateDatabaseRequest)
-	}
-
-	additionalProperties := make(map[string]interface{})
-
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
-		delete(additionalProperties, "name")
-		delete(additionalProperties, "new_name")
-		o.AdditionalProperties = additionalProperties
-	}
-
-	return err
 }

--- a/pkg/client/model_update_sql_user_password_request.go
+++ b/pkg/client/model_update_sql_user_password_request.go
@@ -24,11 +24,8 @@ import (
 
 // UpdateSQLUserPasswordRequest struct for UpdateSQLUserPasswordRequest.
 type UpdateSQLUserPasswordRequest struct {
-	Password             string `json:"password"`
-	AdditionalProperties map[string]interface{}
+	Password string `json:"password"`
 }
-
-type updateSQLUserPasswordRequest UpdateSQLUserPasswordRequest
 
 // NewUpdateSQLUserPasswordRequest instantiates a new UpdateSQLUserPasswordRequest object.
 // This constructor will assign default values to properties that have it defined,
@@ -68,27 +65,5 @@ func (o UpdateSQLUserPasswordRequest) MarshalJSON() ([]byte, error) {
 	if true {
 		toSerialize["password"] = o.Password
 	}
-
-	for key, value := range o.AdditionalProperties {
-		toSerialize[key] = value
-	}
-
 	return json.Marshal(toSerialize)
-}
-
-func (o *UpdateSQLUserPasswordRequest) UnmarshalJSON(bytes []byte) (err error) {
-	varUpdateSQLUserPasswordRequest := updateSQLUserPasswordRequest{}
-
-	if err = json.Unmarshal(bytes, &varUpdateSQLUserPasswordRequest); err == nil {
-		*o = UpdateSQLUserPasswordRequest(varUpdateSQLUserPasswordRequest)
-	}
-
-	additionalProperties := make(map[string]interface{})
-
-	if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
-		delete(additionalProperties, "password")
-		o.AdditionalProperties = additionalProperties
-	}
-
-	return err
 }


### PR DESCRIPTION
Removed `AdditionalProperties` field from all the model struct generated by Go SDK