### PR TITLE
Use default MarshalJSON behavior

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 # Folders
 _obj
 _test
+bin
 
 # Architecture specific extensions/prefixes
 *.[568vq]

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,10 @@
+# TOOLPATH is the location of tools used during builds.
+TOOLPATH := $(abspath bin)
+
 # `brew install openapi-generator` on Mac
 # Installation doc for openapi-generator: https://openapi-generator.tech/docs/installation/
 .PHONY: generate-openapi-client
-generate-openapi-client:
+generate-openapi-client: bin/goimports
 	rm -rf ./pkg/client/*.go docs
 	docker-compose -f ./docker-compose.yml run --rm \
 		jq -M -f filter.jq internal/spec/openapi.json > internal/openapi-generator/api/openapi-modified.json
@@ -14,9 +17,13 @@ generate-openapi-client:
 	mv internal/openapi-generator/docs ./
 	mv internal/openapi-generator/*.md ./docs/
 	cp ./docs/README.md ./
+	bin/goimports -w ./internal/openapi-generator/
 	go fmt ./internal/openapi-generator/...
 	mv ./internal/openapi-generator/*.go pkg/client/
 	@$(MAKE) add-boilerplate
+
+bin/goimports:
+	@TOOLPKG=github.com/cockroachdb/gostdlib/x/tools/cmd/goimports@v1.19.0 $(MAKE) build-tool
 
 .PHONY: fetch-latest-spec
 fetch-latest-spec:
@@ -34,3 +41,16 @@ validate:
 	go run main.go
 
 default: generate-openapi-client validate
+
+# build-tool is a helper that builds $TOOL_PKG in a temp directory so that it
+# can use its own isolated go.mod file.
+.PHONY: build-tool
+build-tool:
+	@{ \
+	TMP_DIR=$$(mktemp -d); \
+	cd $$TMP_DIR; \
+	go mod init tmp; \
+	go get $(TOOLPKG); \
+	GOBIN=$(TOOLPATH) go install $(TOOLPKG); \
+	rm -rf $$TMP_DIR; \
+	}

--- a/internal/spec/templates/model_simple.mustache
+++ b/internal/spec/templates/model_simple.mustache
@@ -122,6 +122,8 @@ func (o *{{classname}}) Set{{name}}(v {{vendorExtensions.x-go-base-type}}) {
 
 {{/required}}
 {{/vars}}
+
+{{#isAdditionalPropertiesTrue}}
 func (o {{classname}}) MarshalJSON() ([]byte, error) {
 	toSerialize := {{#isArray}}make([]interface{}, len(o.Items)){{/isArray}}{{^isArray}}map[string]interface{}{}{{/isArray}}
 	{{#parent}}
@@ -158,7 +160,6 @@ func (o {{classname}}) MarshalJSON() ([]byte, error) {
 	return json.Marshal(toSerialize)
 }
 
-{{#isAdditionalPropertiesTrue}}
 func (o *{{{classname}}}) UnmarshalJSON(bytes []byte) (err error) {
 {{#parent}}
 {{^isMap}}

--- a/pkg/client/model_add_egress_rule_request.go
+++ b/pkg/client/model_add_egress_rule_request.go
@@ -18,10 +18,6 @@
 
 package client
 
-import (
-	"encoding/json"
-)
-
 // AddEgressRuleRequest AddEgressRuleRequest is the input for the rpc AddEgressRule()..
 type AddEgressRuleRequest struct {
 	// description is text that serves to document the rules purpose.
@@ -161,30 +157,4 @@ func (o *AddEgressRuleRequest) GetType() string {
 // SetType sets field value.
 func (o *AddEgressRuleRequest) SetType(v string) {
 	o.Type = v
-}
-
-func (o AddEgressRuleRequest) MarshalJSON() ([]byte, error) {
-	toSerialize := map[string]interface{}{}
-	if true {
-		toSerialize["description"] = o.Description
-	}
-	if true {
-		toSerialize["destination"] = o.Destination
-	}
-	if o.IdempotencyKey != nil {
-		toSerialize["idempotency_key"] = o.IdempotencyKey
-	}
-	if true {
-		toSerialize["name"] = o.Name
-	}
-	if o.Paths != nil {
-		toSerialize["paths"] = o.Paths
-	}
-	if o.Ports != nil {
-		toSerialize["ports"] = o.Ports
-	}
-	if true {
-		toSerialize["type"] = o.Type
-	}
-	return json.Marshal(toSerialize)
 }

--- a/pkg/client/model_add_egress_rule_response.go
+++ b/pkg/client/model_add_egress_rule_response.go
@@ -18,10 +18,6 @@
 
 package client
 
-import (
-	"encoding/json"
-)
-
 // AddEgressRuleResponse AddEgressRuleResponse is the response message of the AddEgressRule RPC..
 type AddEgressRuleResponse struct {
 	Rule *EgressRule `json:"Rule,omitempty"`
@@ -48,12 +44,4 @@ func (o *AddEgressRuleResponse) GetRule() EgressRule {
 // SetRule gets a reference to the given EgressRule and assigns it to the Rule field.
 func (o *AddEgressRuleResponse) SetRule(v EgressRule) {
 	o.Rule = &v
-}
-
-func (o AddEgressRuleResponse) MarshalJSON() ([]byte, error) {
-	toSerialize := map[string]interface{}{}
-	if o.Rule != nil {
-		toSerialize["Rule"] = o.Rule
-	}
-	return json.Marshal(toSerialize)
 }

--- a/pkg/client/model_allowlist_entry.go
+++ b/pkg/client/model_allowlist_entry.go
@@ -18,10 +18,6 @@
 
 package client
 
-import (
-	"encoding/json"
-)
-
 // AllowlistEntry struct for AllowlistEntry.
 type AllowlistEntry struct {
 	CidrIp   string  `json:"cidr_ip"`
@@ -124,24 +120,4 @@ func (o *AllowlistEntry) GetUi() bool {
 // SetUi sets field value.
 func (o *AllowlistEntry) SetUi(v bool) {
 	o.Ui = v
-}
-
-func (o AllowlistEntry) MarshalJSON() ([]byte, error) {
-	toSerialize := map[string]interface{}{}
-	if true {
-		toSerialize["cidr_ip"] = o.CidrIp
-	}
-	if true {
-		toSerialize["cidr_mask"] = o.CidrMask
-	}
-	if o.Name != nil {
-		toSerialize["name"] = o.Name
-	}
-	if true {
-		toSerialize["sql"] = o.Sql
-	}
-	if true {
-		toSerialize["ui"] = o.Ui
-	}
-	return json.Marshal(toSerialize)
 }

--- a/pkg/client/model_allowlist_entry_1.go
+++ b/pkg/client/model_allowlist_entry_1.go
@@ -18,10 +18,6 @@
 
 package client
 
-import (
-	"encoding/json"
-)
-
 // AllowlistEntry1 struct for AllowlistEntry1.
 type AllowlistEntry1 struct {
 	Name *string `json:"name,omitempty"`
@@ -90,18 +86,4 @@ func (o *AllowlistEntry1) GetUi() bool {
 // SetUi sets field value.
 func (o *AllowlistEntry1) SetUi(v bool) {
 	o.Ui = v
-}
-
-func (o AllowlistEntry1) MarshalJSON() ([]byte, error) {
-	toSerialize := map[string]interface{}{}
-	if o.Name != nil {
-		toSerialize["name"] = o.Name
-	}
-	if true {
-		toSerialize["sql"] = o.Sql
-	}
-	if true {
-		toSerialize["ui"] = o.Ui
-	}
-	return json.Marshal(toSerialize)
 }

--- a/pkg/client/model_any.go
+++ b/pkg/client/model_any.go
@@ -18,10 +18,6 @@
 
 package client
 
-import (
-	"encoding/json"
-)
-
 // Any `Any` contains an arbitrary serialized protocol buffer message along with a URL that describes the type of the serialized message.  Protobuf library provides support to pack/unpack Any values in the form of utility functions or additional generated methods of the Any type.  Example 1: Pack and unpack a message in C++.      Foo foo = ...;     Any any;     any.PackFrom(foo);     ...     if (any.UnpackTo(&foo)) {       ...     }  Example 2: Pack and unpack a message in Java.      Foo foo = ...;     Any any = Any.pack(foo);     ...     if (any.is(Foo.class)) {       foo = any.unpack(Foo.class);     }  Example 3: Pack and unpack a message in Python.      foo = Foo(...)     any = Any()     any.Pack(foo)     ...     if any.Is(Foo.DESCRIPTOR):       any.Unpack(foo)       ...  Example 4: Pack and unpack a message in Go       foo := &pb.Foo{...}      any, err := anypb.New(foo)      if err != nil {        ...      }      ...      foo := &pb.Foo{}      if err := any.UnmarshalTo(foo); err != nil {        ...      }  The pack methods provided by protobuf library will by default use 'type.googleapis.com/full.type.name' as the type URL and the unpack methods only use the fully qualified type name after the last '/' in the type URL, for example \"foo.bar.com/x/y.z\" will yield type name \"y.z\".   JSON  The JSON representation of an `Any` value uses the regular representation of the deserialized, embedded message, with an additional field `@type` which contains the type URL. Example:      package google.profile;     message Person {       string first_name = 1;       string last_name = 2;     }      {       \"@type\": \"type.googleapis.com/google.profile.Person\",       \"firstName\": <string>,       \"lastName\": <string>     }  If the embedded message type is well-known and has a custom JSON representation, that representation will be embedded adding a field `value` which holds the custom JSON in addition to the `@type` field. Example (for message [google.protobuf.Duration][]):      {       \"@type\": \"type.googleapis.com/google.protobuf.Duration\",       \"value\": \"1.212s\"     }.
 type Any struct {
 	// A URL/resource name that uniquely identifies the type of the serialized protocol buffer message. This string must contain at least one \"/\" character. The last segment of the URL's path must represent the fully qualified name of the type (as in `path/google.protobuf.Duration`). The name should be in a canonical form (e.g., leading \".\" is not accepted).  In practice, teams usually precompile into the binary all types that they expect it to use in the context of Any. However, for URLs which use the scheme `http`, `https`, or no scheme, one can optionally set up a type server that maps type URLs to message definitions as follows:  * If no scheme is provided, `https` is assumed. * An HTTP GET on the URL must yield a [google.protobuf.Type][]   value in binary format, or produce an error. * Applications are allowed to cache lookup results based on the   URL, or have them precompiled into a binary to avoid any   lookup. Therefore, binary compatibility needs to be preserved   on changes to types. (Use versioned type names to manage   breaking changes.)  Note: this functionality is not currently available in the official protobuf release, and it is not used for type URLs beginning with type.googleapis.com.  Schemes other than `http`, `https` (or the empty scheme) might be used with implementation specific semantics.
@@ -49,12 +45,4 @@ func (o *Any) GetType() string {
 // SetType gets a reference to the given string and assigns it to the Type field.
 func (o *Any) SetType(v string) {
 	o.Type = &v
-}
-
-func (o Any) MarshalJSON() ([]byte, error) {
-	toSerialize := map[string]interface{}{}
-	if o.Type != nil {
-		toSerialize["@type"] = o.Type
-	}
-	return json.Marshal(toSerialize)
 }

--- a/pkg/client/model_api_database.go
+++ b/pkg/client/model_api_database.go
@@ -18,10 +18,6 @@
 
 package client
 
-import (
-	"encoding/json"
-)
-
 // ApiDatabase struct for ApiDatabase.
 type ApiDatabase struct {
 	Name       string `json:"name"`
@@ -73,15 +69,4 @@ func (o *ApiDatabase) GetTableCount() int64 {
 // SetTableCount gets a reference to the given int64 and assigns it to the TableCount field.
 func (o *ApiDatabase) SetTableCount(v int64) {
 	o.TableCount = &v
-}
-
-func (o ApiDatabase) MarshalJSON() ([]byte, error) {
-	toSerialize := map[string]interface{}{}
-	if true {
-		toSerialize["name"] = o.Name
-	}
-	if o.TableCount != nil {
-		toSerialize["table_count"] = o.TableCount
-	}
-	return json.Marshal(toSerialize)
 }

--- a/pkg/client/model_api_list_databases_response.go
+++ b/pkg/client/model_api_list_databases_response.go
@@ -18,10 +18,6 @@
 
 package client
 
-import (
-	"encoding/json"
-)
-
 // ApiListDatabasesResponse struct for ApiListDatabasesResponse.
 type ApiListDatabasesResponse struct {
 	Databases  []ApiDatabase             `json:"databases"`
@@ -73,15 +69,4 @@ func (o *ApiListDatabasesResponse) GetPagination() KeysetPaginationResponse {
 // SetPagination gets a reference to the given KeysetPaginationResponse and assigns it to the Pagination field.
 func (o *ApiListDatabasesResponse) SetPagination(v KeysetPaginationResponse) {
 	o.Pagination = &v
-}
-
-func (o ApiListDatabasesResponse) MarshalJSON() ([]byte, error) {
-	toSerialize := map[string]interface{}{}
-	if true {
-		toSerialize["databases"] = o.Databases
-	}
-	if o.Pagination != nil {
-		toSerialize["pagination"] = o.Pagination
-	}
-	return json.Marshal(toSerialize)
 }

--- a/pkg/client/model_aws_endpoint_connection.go
+++ b/pkg/client/model_aws_endpoint_connection.go
@@ -18,10 +18,6 @@
 
 package client
 
-import (
-	"encoding/json"
-)
-
 // AwsEndpointConnection struct for AwsEndpointConnection.
 type AwsEndpointConnection struct {
 	CloudProvider CloudProviderType `json:"cloud_provider"`
@@ -129,24 +125,4 @@ func (o *AwsEndpointConnection) GetStatus() AWSEndpointConnectionStatusType {
 // SetStatus sets field value.
 func (o *AwsEndpointConnection) SetStatus(v AWSEndpointConnectionStatusType) {
 	o.Status = v
-}
-
-func (o AwsEndpointConnection) MarshalJSON() ([]byte, error) {
-	toSerialize := map[string]interface{}{}
-	if true {
-		toSerialize["cloud_provider"] = o.CloudProvider
-	}
-	if true {
-		toSerialize["endpoint_id"] = o.EndpointId
-	}
-	if true {
-		toSerialize["region_name"] = o.RegionName
-	}
-	if true {
-		toSerialize["service_id"] = o.ServiceId
-	}
-	if true {
-		toSerialize["status"] = o.Status
-	}
-	return json.Marshal(toSerialize)
 }

--- a/pkg/client/model_aws_endpoint_connections.go
+++ b/pkg/client/model_aws_endpoint_connections.go
@@ -18,10 +18,6 @@
 
 package client
 
-import (
-	"encoding/json"
-)
-
 // AwsEndpointConnections struct for AwsEndpointConnections.
 type AwsEndpointConnections struct {
 	// Connections is a list of private endpoints.
@@ -59,12 +55,4 @@ func (o *AwsEndpointConnections) GetConnections() []AwsEndpointConnection {
 // SetConnections sets field value.
 func (o *AwsEndpointConnections) SetConnections(v []AwsEndpointConnection) {
 	o.Connections = v
-}
-
-func (o AwsEndpointConnections) MarshalJSON() ([]byte, error) {
-	toSerialize := map[string]interface{}{}
-	if true {
-		toSerialize["connections"] = o.Connections
-	}
-	return json.Marshal(toSerialize)
 }

--- a/pkg/client/model_aws_private_link_service_detail.go
+++ b/pkg/client/model_aws_private_link_service_detail.go
@@ -18,10 +18,6 @@
 
 package client
 
-import (
-	"encoding/json"
-)
-
 // AWSPrivateLinkServiceDetail struct for AWSPrivateLinkServiceDetail.
 type AWSPrivateLinkServiceDetail struct {
 	// availability_zone_ids are the identifiers for the availability zones that the service is available in.
@@ -95,18 +91,4 @@ func (o *AWSPrivateLinkServiceDetail) GetServiceName() string {
 // SetServiceName sets field value.
 func (o *AWSPrivateLinkServiceDetail) SetServiceName(v string) {
 	o.ServiceName = v
-}
-
-func (o AWSPrivateLinkServiceDetail) MarshalJSON() ([]byte, error) {
-	toSerialize := map[string]interface{}{}
-	if true {
-		toSerialize["availability_zone_ids"] = o.AvailabilityZoneIds
-	}
-	if true {
-		toSerialize["service_id"] = o.ServiceId
-	}
-	if true {
-		toSerialize["service_name"] = o.ServiceName
-	}
-	return json.Marshal(toSerialize)
 }

--- a/pkg/client/model_built_in_role.go
+++ b/pkg/client/model_built_in_role.go
@@ -18,10 +18,6 @@
 
 package client
 
-import (
-	"encoding/json"
-)
-
 // BuiltInRole struct for BuiltInRole.
 type BuiltInRole struct {
 	Name     OrganizationUserRoleType `json:"name"`
@@ -75,15 +71,4 @@ func (o *BuiltInRole) GetResource() Resource {
 // SetResource sets field value.
 func (o *BuiltInRole) SetResource(v Resource) {
 	o.Resource = v
-}
-
-func (o BuiltInRole) MarshalJSON() ([]byte, error) {
-	toSerialize := map[string]interface{}{}
-	if true {
-		toSerialize["name"] = o.Name
-	}
-	if true {
-		toSerialize["resource"] = o.Resource
-	}
-	return json.Marshal(toSerialize)
 }

--- a/pkg/client/model_client_ca_cert_info.go
+++ b/pkg/client/model_client_ca_cert_info.go
@@ -18,10 +18,6 @@
 
 package client
 
-import (
-	"encoding/json"
-)
-
 // ClientCACertInfo struct for ClientCACertInfo.
 type ClientCACertInfo struct {
 	Status      *ClientCACertStatus `json:"status,omitempty"`
@@ -63,15 +59,4 @@ func (o *ClientCACertInfo) GetX509PemCert() string {
 // SetX509PemCert gets a reference to the given string and assigns it to the X509PemCert field.
 func (o *ClientCACertInfo) SetX509PemCert(v string) {
 	o.X509PemCert = &v
-}
-
-func (o ClientCACertInfo) MarshalJSON() ([]byte, error) {
-	toSerialize := map[string]interface{}{}
-	if o.Status != nil {
-		toSerialize["status"] = o.Status
-	}
-	if o.X509PemCert != nil {
-		toSerialize["x509_pem_cert"] = o.X509PemCert
-	}
-	return json.Marshal(toSerialize)
 }

--- a/pkg/client/model_cloud_provider_region.go
+++ b/pkg/client/model_cloud_provider_region.go
@@ -18,10 +18,6 @@
 
 package client
 
-import (
-	"encoding/json"
-)
-
 // CloudProviderRegion struct for CloudProviderRegion.
 type CloudProviderRegion struct {
 	// Distance in miles, based on client IP address.
@@ -127,24 +123,4 @@ func (o *CloudProviderRegion) GetServerless() bool {
 // SetServerless sets field value.
 func (o *CloudProviderRegion) SetServerless(v bool) {
 	o.Serverless = v
-}
-
-func (o CloudProviderRegion) MarshalJSON() ([]byte, error) {
-	toSerialize := map[string]interface{}{}
-	if true {
-		toSerialize["distance"] = o.Distance
-	}
-	if true {
-		toSerialize["location"] = o.Location
-	}
-	if true {
-		toSerialize["name"] = o.Name
-	}
-	if true {
-		toSerialize["provider"] = o.Provider
-	}
-	if true {
-		toSerialize["serverless"] = o.Serverless
-	}
-	return json.Marshal(toSerialize)
 }

--- a/pkg/client/model_cloud_watch_metric_export_info.go
+++ b/pkg/client/model_cloud_watch_metric_export_info.go
@@ -18,10 +18,6 @@
 
 package client
 
-import (
-	"encoding/json"
-)
-
 // CloudWatchMetricExportInfo struct for CloudWatchMetricExportInfo.
 type CloudWatchMetricExportInfo struct {
 	ClusterId string `json:"cluster_id"`
@@ -138,27 +134,4 @@ func (o *CloudWatchMetricExportInfo) GetUserMessage() string {
 // SetUserMessage gets a reference to the given string and assigns it to the UserMessage field.
 func (o *CloudWatchMetricExportInfo) SetUserMessage(v string) {
 	o.UserMessage = &v
-}
-
-func (o CloudWatchMetricExportInfo) MarshalJSON() ([]byte, error) {
-	toSerialize := map[string]interface{}{}
-	if true {
-		toSerialize["cluster_id"] = o.ClusterId
-	}
-	if o.LogGroupName != nil {
-		toSerialize["log_group_name"] = o.LogGroupName
-	}
-	if true {
-		toSerialize["role_arn"] = o.RoleArn
-	}
-	if o.Status != nil {
-		toSerialize["status"] = o.Status
-	}
-	if o.TargetRegion != nil {
-		toSerialize["target_region"] = o.TargetRegion
-	}
-	if o.UserMessage != nil {
-		toSerialize["user_message"] = o.UserMessage
-	}
-	return json.Marshal(toSerialize)
 }

--- a/pkg/client/model_cluster.go
+++ b/pkg/client/model_cluster.go
@@ -19,7 +19,6 @@
 package client
 
 import (
-	"encoding/json"
 	"time"
 )
 
@@ -335,63 +334,4 @@ func (o *Cluster) GetUpgradeStatus() ClusterUpgradeStatusType {
 // SetUpgradeStatus sets field value.
 func (o *Cluster) SetUpgradeStatus(v ClusterUpgradeStatusType) {
 	o.UpgradeStatus = v
-}
-
-func (o Cluster) MarshalJSON() ([]byte, error) {
-	toSerialize := map[string]interface{}{}
-	if o.AccountId != nil {
-		toSerialize["account_id"] = o.AccountId
-	}
-	if true {
-		toSerialize["cloud_provider"] = o.CloudProvider
-	}
-	if true {
-		toSerialize["cockroach_version"] = o.CockroachVersion
-	}
-	if true {
-		toSerialize["config"] = o.Config
-	}
-	if o.CreatedAt != nil {
-		toSerialize["created_at"] = o.CreatedAt
-	}
-	if true {
-		toSerialize["creator_id"] = o.CreatorId
-	}
-	if o.DeletedAt != nil {
-		toSerialize["deleted_at"] = o.DeletedAt
-	}
-	if o.EgressTrafficPolicy != nil {
-		toSerialize["egress_traffic_policy"] = o.EgressTrafficPolicy
-	}
-	if true {
-		toSerialize["id"] = o.Id
-	}
-	if true {
-		toSerialize["name"] = o.Name
-	}
-	if o.NetworkVisibility != nil {
-		toSerialize["network_visibility"] = o.NetworkVisibility
-	}
-	if true {
-		toSerialize["operation_status"] = o.OperationStatus
-	}
-	if true {
-		toSerialize["plan"] = o.Plan
-	}
-	if true {
-		toSerialize["regions"] = o.Regions
-	}
-	if o.SqlDns != nil {
-		toSerialize["sql_dns"] = o.SqlDns
-	}
-	if true {
-		toSerialize["state"] = o.State
-	}
-	if o.UpdatedAt != nil {
-		toSerialize["updated_at"] = o.UpdatedAt
-	}
-	if true {
-		toSerialize["upgrade_status"] = o.UpgradeStatus
-	}
-	return json.Marshal(toSerialize)
 }

--- a/pkg/client/model_cluster_config.go
+++ b/pkg/client/model_cluster_config.go
@@ -18,10 +18,6 @@
 
 package client
 
-import (
-	"encoding/json"
-)
-
 // ClusterConfig struct for ClusterConfig.
 type ClusterConfig struct {
 	Dedicated  *DedicatedHardwareConfig `json:"dedicated,omitempty"`
@@ -63,15 +59,4 @@ func (o *ClusterConfig) GetServerless() ServerlessClusterConfig {
 // SetServerless gets a reference to the given ServerlessClusterConfig and assigns it to the Serverless field.
 func (o *ClusterConfig) SetServerless(v ServerlessClusterConfig) {
 	o.Serverless = &v
-}
-
-func (o ClusterConfig) MarshalJSON() ([]byte, error) {
-	toSerialize := map[string]interface{}{}
-	if o.Dedicated != nil {
-		toSerialize["dedicated"] = o.Dedicated
-	}
-	if o.Serverless != nil {
-		toSerialize["serverless"] = o.Serverless
-	}
-	return json.Marshal(toSerialize)
 }

--- a/pkg/client/model_cluster_major_version.go
+++ b/pkg/client/model_cluster_major_version.go
@@ -18,10 +18,6 @@
 
 package client
 
-import (
-	"encoding/json"
-)
-
 // ClusterMajorVersion For more information about CockroachDB cluster version support, see https://www.cockroachlabs.com/docs/releases/release-support-policy.html.
 type ClusterMajorVersion struct {
 	SupportStatus ClusterMajorVersionSupportStatusType `json:"support_status"`
@@ -75,15 +71,4 @@ func (o *ClusterMajorVersion) GetVersion() string {
 // SetVersion sets field value.
 func (o *ClusterMajorVersion) SetVersion(v string) {
 	o.Version = v
-}
-
-func (o ClusterMajorVersion) MarshalJSON() ([]byte, error) {
-	toSerialize := map[string]interface{}{}
-	if true {
-		toSerialize["support_status"] = o.SupportStatus
-	}
-	if true {
-		toSerialize["version"] = o.Version
-	}
-	return json.Marshal(toSerialize)
 }

--- a/pkg/client/model_cmek_cluster_info.go
+++ b/pkg/client/model_cmek_cluster_info.go
@@ -18,10 +18,6 @@
 
 package client
 
-import (
-	"encoding/json"
-)
-
 // CMEKClusterInfo CMEKClusterInfo contains the status of CMEK across an entire cluster, including within each one its regions..
 type CMEKClusterInfo struct {
 	RegionInfos *[]CMEKRegionInfo `json:"region_infos,omitempty"`
@@ -63,15 +59,4 @@ func (o *CMEKClusterInfo) GetStatus() CMEKStatus {
 // SetStatus gets a reference to the given CMEKStatus and assigns it to the Status field.
 func (o *CMEKClusterInfo) SetStatus(v CMEKStatus) {
 	o.Status = &v
-}
-
-func (o CMEKClusterInfo) MarshalJSON() ([]byte, error) {
-	toSerialize := map[string]interface{}{}
-	if o.RegionInfos != nil {
-		toSerialize["region_infos"] = o.RegionInfos
-	}
-	if o.Status != nil {
-		toSerialize["status"] = o.Status
-	}
-	return json.Marshal(toSerialize)
 }

--- a/pkg/client/model_cmek_cluster_specification.go
+++ b/pkg/client/model_cmek_cluster_specification.go
@@ -18,10 +18,6 @@
 
 package client
 
-import (
-	"encoding/json"
-)
-
 // CMEKClusterSpecification struct for CMEKClusterSpecification.
 type CMEKClusterSpecification struct {
 	RegionSpecs []CMEKRegionSpecification `json:"region_specs"`
@@ -58,12 +54,4 @@ func (o *CMEKClusterSpecification) GetRegionSpecs() []CMEKRegionSpecification {
 // SetRegionSpecs sets field value.
 func (o *CMEKClusterSpecification) SetRegionSpecs(v []CMEKRegionSpecification) {
 	o.RegionSpecs = v
-}
-
-func (o CMEKClusterSpecification) MarshalJSON() ([]byte, error) {
-	toSerialize := map[string]interface{}{}
-	if true {
-		toSerialize["region_specs"] = o.RegionSpecs
-	}
-	return json.Marshal(toSerialize)
 }

--- a/pkg/client/model_cmek_key_info.go
+++ b/pkg/client/model_cmek_key_info.go
@@ -19,7 +19,6 @@
 package client
 
 import (
-	"encoding/json"
 	"time"
 )
 
@@ -109,24 +108,4 @@ func (o *CMEKKeyInfo) GetUserMessage() string {
 // SetUserMessage gets a reference to the given string and assigns it to the UserMessage field.
 func (o *CMEKKeyInfo) SetUserMessage(v string) {
 	o.UserMessage = &v
-}
-
-func (o CMEKKeyInfo) MarshalJSON() ([]byte, error) {
-	toSerialize := map[string]interface{}{}
-	if o.CreatedAt != nil {
-		toSerialize["created_at"] = o.CreatedAt
-	}
-	if o.Spec != nil {
-		toSerialize["spec"] = o.Spec
-	}
-	if o.Status != nil {
-		toSerialize["status"] = o.Status
-	}
-	if o.UpdatedAt != nil {
-		toSerialize["updated_at"] = o.UpdatedAt
-	}
-	if o.UserMessage != nil {
-		toSerialize["user_message"] = o.UserMessage
-	}
-	return json.Marshal(toSerialize)
 }

--- a/pkg/client/model_cmek_key_specification.go
+++ b/pkg/client/model_cmek_key_specification.go
@@ -18,10 +18,6 @@
 
 package client
 
-import (
-	"encoding/json"
-)
-
 // CMEKKeySpecification CMEKKeySpecification contains all the details necessary to use a customer-provided encryption key.  This involves the type/location of the key and the principal to authenticate as  when accessing it..
 type CMEKKeySpecification struct {
 	AuthPrincipal *string      `json:"auth_principal,omitempty"`
@@ -78,18 +74,4 @@ func (o *CMEKKeySpecification) GetUri() string {
 // SetUri gets a reference to the given string and assigns it to the Uri field.
 func (o *CMEKKeySpecification) SetUri(v string) {
 	o.Uri = &v
-}
-
-func (o CMEKKeySpecification) MarshalJSON() ([]byte, error) {
-	toSerialize := map[string]interface{}{}
-	if o.AuthPrincipal != nil {
-		toSerialize["auth_principal"] = o.AuthPrincipal
-	}
-	if o.Type != nil {
-		toSerialize["type"] = o.Type
-	}
-	if o.Uri != nil {
-		toSerialize["uri"] = o.Uri
-	}
-	return json.Marshal(toSerialize)
 }

--- a/pkg/client/model_cmek_region_info.go
+++ b/pkg/client/model_cmek_region_info.go
@@ -18,10 +18,6 @@
 
 package client
 
-import (
-	"encoding/json"
-)
-
 // CMEKRegionInfo CMEKRegionInfo contains the status of CMEK within a region.  This includes current and past key specifications used within the region,  as well as the status of those specifications.
 type CMEKRegionInfo struct {
 	KeyInfos *[]CMEKKeyInfo `json:"key_infos,omitempty"`
@@ -78,18 +74,4 @@ func (o *CMEKRegionInfo) GetStatus() CMEKStatus {
 // SetStatus gets a reference to the given CMEKStatus and assigns it to the Status field.
 func (o *CMEKRegionInfo) SetStatus(v CMEKStatus) {
 	o.Status = &v
-}
-
-func (o CMEKRegionInfo) MarshalJSON() ([]byte, error) {
-	toSerialize := map[string]interface{}{}
-	if o.KeyInfos != nil {
-		toSerialize["key_infos"] = o.KeyInfos
-	}
-	if o.Region != nil {
-		toSerialize["region"] = o.Region
-	}
-	if o.Status != nil {
-		toSerialize["status"] = o.Status
-	}
-	return json.Marshal(toSerialize)
 }

--- a/pkg/client/model_cmek_region_specification.go
+++ b/pkg/client/model_cmek_region_specification.go
@@ -18,10 +18,6 @@
 
 package client
 
-import (
-	"encoding/json"
-)
-
 // CMEKRegionSpecification CMEKRegionSpecification declares the customer-provided key specification that should be used in a given region..
 type CMEKRegionSpecification struct {
 	KeySpec *CMEKKeySpecification `json:"key_spec,omitempty"`
@@ -63,15 +59,4 @@ func (o *CMEKRegionSpecification) GetRegion() string {
 // SetRegion gets a reference to the given string and assigns it to the Region field.
 func (o *CMEKRegionSpecification) SetRegion(v string) {
 	o.Region = &v
-}
-
-func (o CMEKRegionSpecification) MarshalJSON() ([]byte, error) {
-	toSerialize := map[string]interface{}{}
-	if o.KeySpec != nil {
-		toSerialize["key_spec"] = o.KeySpec
-	}
-	if o.Region != nil {
-		toSerialize["region"] = o.Region
-	}
-	return json.Marshal(toSerialize)
 }

--- a/pkg/client/model_cockroach_cloud_set_roles_for_user_request.go
+++ b/pkg/client/model_cockroach_cloud_set_roles_for_user_request.go
@@ -18,10 +18,6 @@
 
 package client
 
-import (
-	"encoding/json"
-)
-
 // CockroachCloudSetRolesForUserRequest struct for CockroachCloudSetRolesForUserRequest.
 type CockroachCloudSetRolesForUserRequest struct {
 	Roles []BuiltInRole `json:"roles"`
@@ -58,12 +54,4 @@ func (o *CockroachCloudSetRolesForUserRequest) GetRoles() []BuiltInRole {
 // SetRoles sets field value.
 func (o *CockroachCloudSetRolesForUserRequest) SetRoles(v []BuiltInRole) {
 	o.Roles = v
-}
-
-func (o CockroachCloudSetRolesForUserRequest) MarshalJSON() ([]byte, error) {
-	toSerialize := map[string]interface{}{}
-	if true {
-		toSerialize["roles"] = o.Roles
-	}
-	return json.Marshal(toSerialize)
 }

--- a/pkg/client/model_create_cluster_request.go
+++ b/pkg/client/model_create_cluster_request.go
@@ -18,10 +18,6 @@
 
 package client
 
-import (
-	"encoding/json"
-)
-
 // CreateClusterRequest struct for CreateClusterRequest.
 type CreateClusterRequest struct {
 	// Name must be 6-20 characters in length and can include numbers, lowercase letters, and dashes (but no leading or trailing dashes).
@@ -93,18 +89,4 @@ func (o *CreateClusterRequest) GetSpec() CreateClusterSpecification {
 // SetSpec sets field value.
 func (o *CreateClusterRequest) SetSpec(v CreateClusterSpecification) {
 	o.Spec = v
-}
-
-func (o CreateClusterRequest) MarshalJSON() ([]byte, error) {
-	toSerialize := map[string]interface{}{}
-	if true {
-		toSerialize["name"] = o.Name
-	}
-	if true {
-		toSerialize["provider"] = o.Provider
-	}
-	if true {
-		toSerialize["spec"] = o.Spec
-	}
-	return json.Marshal(toSerialize)
 }

--- a/pkg/client/model_create_cluster_specification.go
+++ b/pkg/client/model_create_cluster_specification.go
@@ -18,10 +18,6 @@
 
 package client
 
-import (
-	"encoding/json"
-)
-
 // CreateClusterSpecification struct for CreateClusterSpecification.
 type CreateClusterSpecification struct {
 	Dedicated  *DedicatedClusterCreateSpecification  `json:"dedicated,omitempty"`
@@ -63,15 +59,4 @@ func (o *CreateClusterSpecification) GetServerless() ServerlessClusterCreateSpec
 // SetServerless gets a reference to the given ServerlessClusterCreateSpecification and assigns it to the Serverless field.
 func (o *CreateClusterSpecification) SetServerless(v ServerlessClusterCreateSpecification) {
 	o.Serverless = &v
-}
-
-func (o CreateClusterSpecification) MarshalJSON() ([]byte, error) {
-	toSerialize := map[string]interface{}{}
-	if o.Dedicated != nil {
-		toSerialize["dedicated"] = o.Dedicated
-	}
-	if o.Serverless != nil {
-		toSerialize["serverless"] = o.Serverless
-	}
-	return json.Marshal(toSerialize)
 }

--- a/pkg/client/model_create_database_request.go
+++ b/pkg/client/model_create_database_request.go
@@ -18,10 +18,6 @@
 
 package client
 
-import (
-	"encoding/json"
-)
-
 // CreateDatabaseRequest struct for CreateDatabaseRequest.
 type CreateDatabaseRequest struct {
 	Name string `json:"name"`
@@ -58,12 +54,4 @@ func (o *CreateDatabaseRequest) GetName() string {
 // SetName sets field value.
 func (o *CreateDatabaseRequest) SetName(v string) {
 	o.Name = v
-}
-
-func (o CreateDatabaseRequest) MarshalJSON() ([]byte, error) {
-	toSerialize := map[string]interface{}{}
-	if true {
-		toSerialize["name"] = o.Name
-	}
-	return json.Marshal(toSerialize)
 }

--- a/pkg/client/model_create_sql_user_request.go
+++ b/pkg/client/model_create_sql_user_request.go
@@ -18,10 +18,6 @@
 
 package client
 
-import (
-	"encoding/json"
-)
-
 // CreateSQLUserRequest struct for CreateSQLUserRequest.
 type CreateSQLUserRequest struct {
 	Name     string `json:"name"`
@@ -75,15 +71,4 @@ func (o *CreateSQLUserRequest) GetPassword() string {
 // SetPassword sets field value.
 func (o *CreateSQLUserRequest) SetPassword(v string) {
 	o.Password = v
-}
-
-func (o CreateSQLUserRequest) MarshalJSON() ([]byte, error) {
-	toSerialize := map[string]interface{}{}
-	if true {
-		toSerialize["name"] = o.Name
-	}
-	if true {
-		toSerialize["password"] = o.Password
-	}
-	return json.Marshal(toSerialize)
 }

--- a/pkg/client/model_currency_amount.go
+++ b/pkg/client/model_currency_amount.go
@@ -18,10 +18,6 @@
 
 package client
 
-import (
-	"encoding/json"
-)
-
 // CurrencyAmount struct for CurrencyAmount.
 type CurrencyAmount struct {
 	// amount is the quantity of currency. Internally, currency amounts are tracked and stored using an arbitrary-precision decimal representation, but are serialized as 64-bit floating point numbers. There may be minor rounding discrepancies when parsed as a 32-bit float.
@@ -64,15 +60,4 @@ func (o *CurrencyAmount) GetCurrency() CurrencyType {
 // SetCurrency gets a reference to the given CurrencyType and assigns it to the Currency field.
 func (o *CurrencyAmount) SetCurrency(v CurrencyType) {
 	o.Currency = &v
-}
-
-func (o CurrencyAmount) MarshalJSON() ([]byte, error) {
-	toSerialize := map[string]interface{}{}
-	if o.Amount != nil {
-		toSerialize["amount"] = o.Amount
-	}
-	if o.Currency != nil {
-		toSerialize["currency"] = o.Currency
-	}
-	return json.Marshal(toSerialize)
 }

--- a/pkg/client/model_datadog_metric_export_info.go
+++ b/pkg/client/model_datadog_metric_export_info.go
@@ -18,10 +18,6 @@
 
 package client
 
-import (
-	"encoding/json"
-)
-
 // DatadogMetricExportInfo struct for DatadogMetricExportInfo.
 type DatadogMetricExportInfo struct {
 	// api_key is the last 4 digits of a Datadog API key.
@@ -121,24 +117,4 @@ func (o *DatadogMetricExportInfo) GetUserMessage() string {
 // SetUserMessage gets a reference to the given string and assigns it to the UserMessage field.
 func (o *DatadogMetricExportInfo) SetUserMessage(v string) {
 	o.UserMessage = &v
-}
-
-func (o DatadogMetricExportInfo) MarshalJSON() ([]byte, error) {
-	toSerialize := map[string]interface{}{}
-	if o.ApiKey != nil {
-		toSerialize["api_key"] = o.ApiKey
-	}
-	if true {
-		toSerialize["cluster_id"] = o.ClusterId
-	}
-	if true {
-		toSerialize["site"] = o.Site
-	}
-	if o.Status != nil {
-		toSerialize["status"] = o.Status
-	}
-	if o.UserMessage != nil {
-		toSerialize["user_message"] = o.UserMessage
-	}
-	return json.Marshal(toSerialize)
 }

--- a/pkg/client/model_dedicated_cluster_create_specification.go
+++ b/pkg/client/model_dedicated_cluster_create_specification.go
@@ -18,10 +18,6 @@
 
 package client
 
-import (
-	"encoding/json"
-)
-
 // DedicatedClusterCreateSpecification struct for DedicatedClusterCreateSpecification.
 type DedicatedClusterCreateSpecification struct {
 	// The CockroachDB version for the cluster. The current version is used if omitted.
@@ -123,24 +119,4 @@ func (o *DedicatedClusterCreateSpecification) GetRestrictEgressTraffic() bool {
 // SetRestrictEgressTraffic gets a reference to the given bool and assigns it to the RestrictEgressTraffic field.
 func (o *DedicatedClusterCreateSpecification) SetRestrictEgressTraffic(v bool) {
 	o.RestrictEgressTraffic = &v
-}
-
-func (o DedicatedClusterCreateSpecification) MarshalJSON() ([]byte, error) {
-	toSerialize := map[string]interface{}{}
-	if o.CockroachVersion != nil {
-		toSerialize["cockroach_version"] = o.CockroachVersion
-	}
-	if true {
-		toSerialize["hardware"] = o.Hardware
-	}
-	if o.NetworkVisibility != nil {
-		toSerialize["network_visibility"] = o.NetworkVisibility
-	}
-	if true {
-		toSerialize["region_nodes"] = o.RegionNodes
-	}
-	if o.RestrictEgressTraffic != nil {
-		toSerialize["restrict_egress_traffic"] = o.RestrictEgressTraffic
-	}
-	return json.Marshal(toSerialize)
 }

--- a/pkg/client/model_dedicated_cluster_update_specification.go
+++ b/pkg/client/model_dedicated_cluster_update_specification.go
@@ -18,10 +18,6 @@
 
 package client
 
-import (
-	"encoding/json"
-)
-
 // DedicatedClusterUpdateSpecification struct for DedicatedClusterUpdateSpecification.
 type DedicatedClusterUpdateSpecification struct {
 	// This field should contain the CMEK specs for newly added regions. If a CMEK spec is provided for an existing region, the request is invalid and will fail.
@@ -80,18 +76,4 @@ func (o *DedicatedClusterUpdateSpecification) GetRegionNodes() map[string]int32 
 // SetRegionNodes gets a reference to the given map[string]int32 and assigns it to the RegionNodes field.
 func (o *DedicatedClusterUpdateSpecification) SetRegionNodes(v map[string]int32) {
 	o.RegionNodes = &v
-}
-
-func (o DedicatedClusterUpdateSpecification) MarshalJSON() ([]byte, error) {
-	toSerialize := map[string]interface{}{}
-	if o.CmekRegionSpecs != nil {
-		toSerialize["cmek_region_specs"] = o.CmekRegionSpecs
-	}
-	if o.Hardware != nil {
-		toSerialize["hardware"] = o.Hardware
-	}
-	if o.RegionNodes != nil {
-		toSerialize["region_nodes"] = o.RegionNodes
-	}
-	return json.Marshal(toSerialize)
 }

--- a/pkg/client/model_dedicated_hardware_config.go
+++ b/pkg/client/model_dedicated_hardware_config.go
@@ -18,10 +18,6 @@
 
 package client
 
-import (
-	"encoding/json"
-)
-
 // DedicatedHardwareConfig struct for DedicatedHardwareConfig.
 type DedicatedHardwareConfig struct {
 	// disk_iops is the number of disk I/O operations per second that are permitted on each node in the cluster. Zero indicates the cloud provider-specific default.
@@ -131,24 +127,4 @@ func (o *DedicatedHardwareConfig) GetStorageGib() int32 {
 // SetStorageGib sets field value.
 func (o *DedicatedHardwareConfig) SetStorageGib(v int32) {
 	o.StorageGib = v
-}
-
-func (o DedicatedHardwareConfig) MarshalJSON() ([]byte, error) {
-	toSerialize := map[string]interface{}{}
-	if true {
-		toSerialize["disk_iops"] = o.DiskIops
-	}
-	if true {
-		toSerialize["machine_type"] = o.MachineType
-	}
-	if true {
-		toSerialize["memory_gib"] = o.MemoryGib
-	}
-	if true {
-		toSerialize["num_virtual_cpus"] = o.NumVirtualCpus
-	}
-	if true {
-		toSerialize["storage_gib"] = o.StorageGib
-	}
-	return json.Marshal(toSerialize)
 }

--- a/pkg/client/model_dedicated_hardware_create_specification.go
+++ b/pkg/client/model_dedicated_hardware_create_specification.go
@@ -18,10 +18,6 @@
 
 package client
 
-import (
-	"encoding/json"
-)
-
 // DedicatedHardwareCreateSpecification struct for DedicatedHardwareCreateSpecification.
 type DedicatedHardwareCreateSpecification struct {
 	// disk_iops is the number of disk I/O operations per second that are permitted on each node in the cluster. Zero indicates the cloud provider-specific default. Only available for AWS clusters.
@@ -92,18 +88,4 @@ func (o *DedicatedHardwareCreateSpecification) GetStorageGib() int32 {
 // SetStorageGib sets field value.
 func (o *DedicatedHardwareCreateSpecification) SetStorageGib(v int32) {
 	o.StorageGib = v
-}
-
-func (o DedicatedHardwareCreateSpecification) MarshalJSON() ([]byte, error) {
-	toSerialize := map[string]interface{}{}
-	if o.DiskIops != nil {
-		toSerialize["disk_iops"] = o.DiskIops
-	}
-	if true {
-		toSerialize["machine_spec"] = o.MachineSpec
-	}
-	if true {
-		toSerialize["storage_gib"] = o.StorageGib
-	}
-	return json.Marshal(toSerialize)
 }

--- a/pkg/client/model_dedicated_hardware_update_specification.go
+++ b/pkg/client/model_dedicated_hardware_update_specification.go
@@ -18,10 +18,6 @@
 
 package client
 
-import (
-	"encoding/json"
-)
-
 // DedicatedHardwareUpdateSpecification struct for DedicatedHardwareUpdateSpecification.
 type DedicatedHardwareUpdateSpecification struct {
 	// disk_iops is the number of disk I/O operations per second that are permitted on each node in the cluster. Zero indicates the cloud provider-specific default. Only available for AWS clusters.
@@ -80,18 +76,4 @@ func (o *DedicatedHardwareUpdateSpecification) GetStorageGib() int32 {
 // SetStorageGib gets a reference to the given int32 and assigns it to the StorageGib field.
 func (o *DedicatedHardwareUpdateSpecification) SetStorageGib(v int32) {
 	o.StorageGib = &v
-}
-
-func (o DedicatedHardwareUpdateSpecification) MarshalJSON() ([]byte, error) {
-	toSerialize := map[string]interface{}{}
-	if o.DiskIops != nil {
-		toSerialize["disk_iops"] = o.DiskIops
-	}
-	if o.MachineSpec != nil {
-		toSerialize["machine_spec"] = o.MachineSpec
-	}
-	if o.StorageGib != nil {
-		toSerialize["storage_gib"] = o.StorageGib
-	}
-	return json.Marshal(toSerialize)
 }

--- a/pkg/client/model_dedicated_machine_type_specification.go
+++ b/pkg/client/model_dedicated_machine_type_specification.go
@@ -18,10 +18,6 @@
 
 package client
 
-import (
-	"encoding/json"
-)
-
 // DedicatedMachineTypeSpecification struct for DedicatedMachineTypeSpecification.
 type DedicatedMachineTypeSpecification struct {
 	// machine_type is the machine type identifier within the given cloud provider, ex. m5.xlarge, n2-standard-4.
@@ -65,15 +61,4 @@ func (o *DedicatedMachineTypeSpecification) GetNumVirtualCpus() int32 {
 // SetNumVirtualCpus gets a reference to the given int32 and assigns it to the NumVirtualCpus field.
 func (o *DedicatedMachineTypeSpecification) SetNumVirtualCpus(v int32) {
 	o.NumVirtualCpus = &v
-}
-
-func (o DedicatedMachineTypeSpecification) MarshalJSON() ([]byte, error) {
-	toSerialize := map[string]interface{}{}
-	if o.MachineType != nil {
-		toSerialize["machine_type"] = o.MachineType
-	}
-	if o.NumVirtualCpus != nil {
-		toSerialize["num_virtual_cpus"] = o.NumVirtualCpus
-	}
-	return json.Marshal(toSerialize)
 }

--- a/pkg/client/model_delete_egress_rule_response.go
+++ b/pkg/client/model_delete_egress_rule_response.go
@@ -18,10 +18,6 @@
 
 package client
 
-import (
-	"encoding/json"
-)
-
 // DeleteEgressRuleResponse DeleteEgressRuleResponse is the output for the DeleteEgressRule RPC..
 type DeleteEgressRuleResponse struct {
 	Rule *EgressRule `json:"Rule,omitempty"`
@@ -48,12 +44,4 @@ func (o *DeleteEgressRuleResponse) GetRule() EgressRule {
 // SetRule gets a reference to the given EgressRule and assigns it to the Rule field.
 func (o *DeleteEgressRuleResponse) SetRule(v EgressRule) {
 	o.Rule = &v
-}
-
-func (o DeleteEgressRuleResponse) MarshalJSON() ([]byte, error) {
-	toSerialize := map[string]interface{}{}
-	if o.Rule != nil {
-		toSerialize["Rule"] = o.Rule
-	}
-	return json.Marshal(toSerialize)
 }

--- a/pkg/client/model_delete_metric_export_response.go
+++ b/pkg/client/model_delete_metric_export_response.go
@@ -18,10 +18,6 @@
 
 package client
 
-import (
-	"encoding/json"
-)
-
 // DeleteMetricExportResponse struct for DeleteMetricExportResponse.
 type DeleteMetricExportResponse struct {
 	ClusterId string                  `json:"cluster_id"`
@@ -73,15 +69,4 @@ func (o *DeleteMetricExportResponse) GetStatus() MetricExportStatusType {
 // SetStatus gets a reference to the given MetricExportStatusType and assigns it to the Status field.
 func (o *DeleteMetricExportResponse) SetStatus(v MetricExportStatusType) {
 	o.Status = &v
-}
-
-func (o DeleteMetricExportResponse) MarshalJSON() ([]byte, error) {
-	toSerialize := map[string]interface{}{}
-	if true {
-		toSerialize["cluster_id"] = o.ClusterId
-	}
-	if o.Status != nil {
-		toSerialize["status"] = o.Status
-	}
-	return json.Marshal(toSerialize)
 }

--- a/pkg/client/model_edit_egress_rule_request.go
+++ b/pkg/client/model_edit_egress_rule_request.go
@@ -18,10 +18,6 @@
 
 package client
 
-import (
-	"encoding/json"
-)
-
 // EditEgressRuleRequest EditEgressRuleRequest is the input message to the EditEgressRule RPC..
 type EditEgressRuleRequest struct {
 	// description is text that serves to document the rules purpose.
@@ -129,27 +125,4 @@ func (o *EditEgressRuleRequest) GetType() string {
 // SetType gets a reference to the given string and assigns it to the Type field.
 func (o *EditEgressRuleRequest) SetType(v string) {
 	o.Type = &v
-}
-
-func (o EditEgressRuleRequest) MarshalJSON() ([]byte, error) {
-	toSerialize := map[string]interface{}{}
-	if o.Description != nil {
-		toSerialize["description"] = o.Description
-	}
-	if o.Destination != nil {
-		toSerialize["destination"] = o.Destination
-	}
-	if o.IdempotencyKey != nil {
-		toSerialize["idempotency_key"] = o.IdempotencyKey
-	}
-	if o.Paths != nil {
-		toSerialize["paths"] = o.Paths
-	}
-	if o.Ports != nil {
-		toSerialize["ports"] = o.Ports
-	}
-	if o.Type != nil {
-		toSerialize["type"] = o.Type
-	}
-	return json.Marshal(toSerialize)
 }

--- a/pkg/client/model_edit_egress_rule_response.go
+++ b/pkg/client/model_edit_egress_rule_response.go
@@ -18,10 +18,6 @@
 
 package client
 
-import (
-	"encoding/json"
-)
-
 // EditEgressRuleResponse EditEgressRuleResponse is the output message to the EditEgressRule RPC..
 type EditEgressRuleResponse struct {
 	Rule *EgressRule `json:"Rule,omitempty"`
@@ -48,12 +44,4 @@ func (o *EditEgressRuleResponse) GetRule() EgressRule {
 // SetRule gets a reference to the given EgressRule and assigns it to the Rule field.
 func (o *EditEgressRuleResponse) SetRule(v EgressRule) {
 	o.Rule = &v
-}
-
-func (o EditEgressRuleResponse) MarshalJSON() ([]byte, error) {
-	toSerialize := map[string]interface{}{}
-	if o.Rule != nil {
-		toSerialize["Rule"] = o.Rule
-	}
-	return json.Marshal(toSerialize)
 }

--- a/pkg/client/model_egress_rule.go
+++ b/pkg/client/model_egress_rule.go
@@ -19,7 +19,6 @@
 package client
 
 import (
-	"encoding/json"
 	"time"
 )
 
@@ -234,42 +233,4 @@ func (o *EgressRule) GetType() string {
 // SetType sets field value.
 func (o *EgressRule) SetType(v string) {
 	o.Type = v
-}
-
-func (o EgressRule) MarshalJSON() ([]byte, error) {
-	toSerialize := map[string]interface{}{}
-	if true {
-		toSerialize["cluster_id"] = o.ClusterId
-	}
-	if o.CreatedAt != nil {
-		toSerialize["created_at"] = o.CreatedAt
-	}
-	if true {
-		toSerialize["crl_managed"] = o.CrlManaged
-	}
-	if true {
-		toSerialize["description"] = o.Description
-	}
-	if true {
-		toSerialize["destination"] = o.Destination
-	}
-	if true {
-		toSerialize["id"] = o.Id
-	}
-	if true {
-		toSerialize["name"] = o.Name
-	}
-	if o.Paths != nil {
-		toSerialize["paths"] = o.Paths
-	}
-	if o.Ports != nil {
-		toSerialize["ports"] = o.Ports
-	}
-	if true {
-		toSerialize["state"] = o.State
-	}
-	if true {
-		toSerialize["type"] = o.Type
-	}
-	return json.Marshal(toSerialize)
 }

--- a/pkg/client/model_enable_cloud_watch_metric_export_request.go
+++ b/pkg/client/model_enable_cloud_watch_metric_export_request.go
@@ -18,10 +18,6 @@
 
 package client
 
-import (
-	"encoding/json"
-)
-
 // EnableCloudWatchMetricExportRequest struct for EnableCloudWatchMetricExportRequest.
 type EnableCloudWatchMetricExportRequest struct {
 	// log_group_name is the customized log group name.
@@ -91,18 +87,4 @@ func (o *EnableCloudWatchMetricExportRequest) GetTargetRegion() string {
 // SetTargetRegion gets a reference to the given string and assigns it to the TargetRegion field.
 func (o *EnableCloudWatchMetricExportRequest) SetTargetRegion(v string) {
 	o.TargetRegion = &v
-}
-
-func (o EnableCloudWatchMetricExportRequest) MarshalJSON() ([]byte, error) {
-	toSerialize := map[string]interface{}{}
-	if o.LogGroupName != nil {
-		toSerialize["log_group_name"] = o.LogGroupName
-	}
-	if true {
-		toSerialize["role_arn"] = o.RoleArn
-	}
-	if o.TargetRegion != nil {
-		toSerialize["target_region"] = o.TargetRegion
-	}
-	return json.Marshal(toSerialize)
 }

--- a/pkg/client/model_enable_datadog_metric_export_request.go
+++ b/pkg/client/model_enable_datadog_metric_export_request.go
@@ -18,10 +18,6 @@
 
 package client
 
-import (
-	"encoding/json"
-)
-
 // EnableDatadogMetricExportRequest struct for EnableDatadogMetricExportRequest.
 type EnableDatadogMetricExportRequest struct {
 	// api_key is a Datadog API key.
@@ -76,15 +72,4 @@ func (o *EnableDatadogMetricExportRequest) GetSite() DatadogSiteType {
 // SetSite sets field value.
 func (o *EnableDatadogMetricExportRequest) SetSite(v DatadogSiteType) {
 	o.Site = v
-}
-
-func (o EnableDatadogMetricExportRequest) MarshalJSON() ([]byte, error) {
-	toSerialize := map[string]interface{}{}
-	if true {
-		toSerialize["api_key"] = o.ApiKey
-	}
-	if true {
-		toSerialize["site"] = o.Site
-	}
-	return json.Marshal(toSerialize)
 }

--- a/pkg/client/model_enable_log_export_request.go
+++ b/pkg/client/model_enable_log_export_request.go
@@ -18,10 +18,6 @@
 
 package client
 
-import (
-	"encoding/json"
-)
-
 // EnableLogExportRequest struct for EnableLogExportRequest.
 type EnableLogExportRequest struct {
 	// auth_principal is either the AWS Role ARN that identifies a role that the cluster account can assume to write to CloudWatch or the GCP Project ID that the cluster service account has permissions to write to for cloud logging.
@@ -142,27 +138,4 @@ func (o *EnableLogExportRequest) GetType() LogExportType {
 // SetType sets field value.
 func (o *EnableLogExportRequest) SetType(v LogExportType) {
 	o.Type = v
-}
-
-func (o EnableLogExportRequest) MarshalJSON() ([]byte, error) {
-	toSerialize := map[string]interface{}{}
-	if true {
-		toSerialize["auth_principal"] = o.AuthPrincipal
-	}
-	if o.Groups != nil {
-		toSerialize["groups"] = o.Groups
-	}
-	if true {
-		toSerialize["log_name"] = o.LogName
-	}
-	if o.Redact != nil {
-		toSerialize["redact"] = o.Redact
-	}
-	if o.Region != nil {
-		toSerialize["region"] = o.Region
-	}
-	if true {
-		toSerialize["type"] = o.Type
-	}
-	return json.Marshal(toSerialize)
 }

--- a/pkg/client/model_get_all_roles_for_user_response.go
+++ b/pkg/client/model_get_all_roles_for_user_response.go
@@ -18,10 +18,6 @@
 
 package client
 
-import (
-	"encoding/json"
-)
-
 // GetAllRolesForUserResponse struct for GetAllRolesForUserResponse.
 type GetAllRolesForUserResponse struct {
 	Roles *[]BuiltInRole `json:"roles,omitempty"`
@@ -48,12 +44,4 @@ func (o *GetAllRolesForUserResponse) GetRoles() []BuiltInRole {
 // SetRoles gets a reference to the given []BuiltInRole and assigns it to the Roles field.
 func (o *GetAllRolesForUserResponse) SetRoles(v []BuiltInRole) {
 	o.Roles = &v
-}
-
-func (o GetAllRolesForUserResponse) MarshalJSON() ([]byte, error) {
-	toSerialize := map[string]interface{}{}
-	if o.Roles != nil {
-		toSerialize["roles"] = o.Roles
-	}
-	return json.Marshal(toSerialize)
 }

--- a/pkg/client/model_get_connection_string_response.go
+++ b/pkg/client/model_get_connection_string_response.go
@@ -18,10 +18,6 @@
 
 package client
 
-import (
-	"encoding/json"
-)
-
 // GetConnectionStringResponse struct for GetConnectionStringResponse.
 type GetConnectionStringResponse struct {
 	// connection_string contains the full connection string with parameters formatted inline.
@@ -65,15 +61,4 @@ func (o *GetConnectionStringResponse) GetParams() map[string]string {
 // SetParams gets a reference to the given map[string]string and assigns it to the Params field.
 func (o *GetConnectionStringResponse) SetParams(v map[string]string) {
 	o.Params = &v
-}
-
-func (o GetConnectionStringResponse) MarshalJSON() ([]byte, error) {
-	toSerialize := map[string]interface{}{}
-	if o.ConnectionString != nil {
-		toSerialize["connection_string"] = o.ConnectionString
-	}
-	if o.Params != nil {
-		toSerialize["params"] = o.Params
-	}
-	return json.Marshal(toSerialize)
 }

--- a/pkg/client/model_get_egress_rule_response.go
+++ b/pkg/client/model_get_egress_rule_response.go
@@ -18,10 +18,6 @@
 
 package client
 
-import (
-	"encoding/json"
-)
-
 // GetEgressRuleResponse GetEgressRuleResponse is the response message to the GetEgressRule RPC..
 type GetEgressRuleResponse struct {
 	Rule EgressRule `json:"rule"`
@@ -58,12 +54,4 @@ func (o *GetEgressRuleResponse) GetRule() EgressRule {
 // SetRule sets field value.
 func (o *GetEgressRuleResponse) SetRule(v EgressRule) {
 	o.Rule = v
-}
-
-func (o GetEgressRuleResponse) MarshalJSON() ([]byte, error) {
-	toSerialize := map[string]interface{}{}
-	if true {
-		toSerialize["rule"] = o.Rule
-	}
-	return json.Marshal(toSerialize)
 }

--- a/pkg/client/model_get_person_users_by_email_response.go
+++ b/pkg/client/model_get_person_users_by_email_response.go
@@ -18,10 +18,6 @@
 
 package client
 
-import (
-	"encoding/json"
-)
-
 // GetPersonUsersByEmailResponse struct for GetPersonUsersByEmailResponse.
 type GetPersonUsersByEmailResponse struct {
 	User *PersonUserInfo `json:"user,omitempty"`
@@ -48,12 +44,4 @@ func (o *GetPersonUsersByEmailResponse) GetUser() PersonUserInfo {
 // SetUser gets a reference to the given PersonUserInfo and assigns it to the User field.
 func (o *GetPersonUsersByEmailResponse) SetUser(v PersonUserInfo) {
 	o.User = &v
-}
-
-func (o GetPersonUsersByEmailResponse) MarshalJSON() ([]byte, error) {
-	toSerialize := map[string]interface{}{}
-	if o.User != nil {
-		toSerialize["user"] = o.User
-	}
-	return json.Marshal(toSerialize)
 }

--- a/pkg/client/model_invoice.go
+++ b/pkg/client/model_invoice.go
@@ -19,7 +19,6 @@
 package client
 
 import (
-	"encoding/json"
 	"time"
 )
 
@@ -166,30 +165,4 @@ func (o *Invoice) GetTotals() []CurrencyAmount {
 // SetTotals sets field value.
 func (o *Invoice) SetTotals(v []CurrencyAmount) {
 	o.Totals = v
-}
-
-func (o Invoice) MarshalJSON() ([]byte, error) {
-	toSerialize := map[string]interface{}{}
-	if o.Adjustments != nil {
-		toSerialize["adjustments"] = o.Adjustments
-	}
-	if true {
-		toSerialize["balances"] = o.Balances
-	}
-	if true {
-		toSerialize["invoice_id"] = o.InvoiceId
-	}
-	if true {
-		toSerialize["invoice_items"] = o.InvoiceItems
-	}
-	if true {
-		toSerialize["period_end"] = o.PeriodEnd
-	}
-	if true {
-		toSerialize["period_start"] = o.PeriodStart
-	}
-	if true {
-		toSerialize["totals"] = o.Totals
-	}
-	return json.Marshal(toSerialize)
 }

--- a/pkg/client/model_invoice_adjustment.go
+++ b/pkg/client/model_invoice_adjustment.go
@@ -18,10 +18,6 @@
 
 package client
 
-import (
-	"encoding/json"
-)
-
 // InvoiceAdjustment struct for InvoiceAdjustment.
 type InvoiceAdjustment struct {
 	Amount CurrencyAmount `json:"amount"`
@@ -76,15 +72,4 @@ func (o *InvoiceAdjustment) GetName() string {
 // SetName sets field value.
 func (o *InvoiceAdjustment) SetName(v string) {
 	o.Name = v
-}
-
-func (o InvoiceAdjustment) MarshalJSON() ([]byte, error) {
-	toSerialize := map[string]interface{}{}
-	if true {
-		toSerialize["amount"] = o.Amount
-	}
-	if true {
-		toSerialize["name"] = o.Name
-	}
-	return json.Marshal(toSerialize)
 }

--- a/pkg/client/model_invoice_item.go
+++ b/pkg/client/model_invoice_item.go
@@ -18,10 +18,6 @@
 
 package client
 
-import (
-	"encoding/json"
-)
-
 // InvoiceItem struct for InvoiceItem.
 type InvoiceItem struct {
 	Cluster Cluster `json:"cluster"`
@@ -94,18 +90,4 @@ func (o *InvoiceItem) GetTotals() []CurrencyAmount {
 // SetTotals sets field value.
 func (o *InvoiceItem) SetTotals(v []CurrencyAmount) {
 	o.Totals = v
-}
-
-func (o InvoiceItem) MarshalJSON() ([]byte, error) {
-	toSerialize := map[string]interface{}{}
-	if true {
-		toSerialize["cluster"] = o.Cluster
-	}
-	if true {
-		toSerialize["line_items"] = o.LineItems
-	}
-	if true {
-		toSerialize["totals"] = o.Totals
-	}
-	return json.Marshal(toSerialize)
 }

--- a/pkg/client/model_keyset_pagination_request.go
+++ b/pkg/client/model_keyset_pagination_request.go
@@ -19,7 +19,6 @@
 package client
 
 import (
-	"encoding/json"
 	"time"
 )
 
@@ -94,21 +93,4 @@ func (o *KeysetPaginationRequest) GetSortOrder() SortOrder {
 // SetSortOrder gets a reference to the given SortOrder and assigns it to the SortOrder field.
 func (o *KeysetPaginationRequest) SetSortOrder(v SortOrder) {
 	o.SortOrder = &v
-}
-
-func (o KeysetPaginationRequest) MarshalJSON() ([]byte, error) {
-	toSerialize := map[string]interface{}{}
-	if o.AsOfTime != nil {
-		toSerialize["as_of_time"] = o.AsOfTime
-	}
-	if o.Limit != nil {
-		toSerialize["limit"] = o.Limit
-	}
-	if o.Page != nil {
-		toSerialize["page"] = o.Page
-	}
-	if o.SortOrder != nil {
-		toSerialize["sort_order"] = o.SortOrder
-	}
-	return json.Marshal(toSerialize)
 }

--- a/pkg/client/model_keyset_pagination_response.go
+++ b/pkg/client/model_keyset_pagination_response.go
@@ -18,10 +18,6 @@
 
 package client
 
-import (
-	"encoding/json"
-)
-
 // KeysetPaginationResponse struct for KeysetPaginationResponse.
 type KeysetPaginationResponse struct {
 	NextPage     *string `json:"next_page,omitempty"`
@@ -63,15 +59,4 @@ func (o *KeysetPaginationResponse) GetPreviousPage() string {
 // SetPreviousPage gets a reference to the given string and assigns it to the PreviousPage field.
 func (o *KeysetPaginationResponse) SetPreviousPage(v string) {
 	o.PreviousPage = &v
-}
-
-func (o KeysetPaginationResponse) MarshalJSON() ([]byte, error) {
-	toSerialize := map[string]interface{}{}
-	if o.NextPage != nil {
-		toSerialize["next_page"] = o.NextPage
-	}
-	if o.PreviousPage != nil {
-		toSerialize["previous_page"] = o.PreviousPage
-	}
-	return json.Marshal(toSerialize)
 }

--- a/pkg/client/model_line_item.go
+++ b/pkg/client/model_line_item.go
@@ -18,10 +18,6 @@
 
 package client
 
-import (
-	"encoding/json"
-)
-
 // LineItem struct for LineItem.
 type LineItem struct {
 	// description contains the details of the line item (i.e t3 micro).
@@ -129,24 +125,4 @@ func (o *LineItem) GetUnitCost() float64 {
 // SetUnitCost sets field value.
 func (o *LineItem) SetUnitCost(v float64) {
 	o.UnitCost = v
-}
-
-func (o LineItem) MarshalJSON() ([]byte, error) {
-	toSerialize := map[string]interface{}{}
-	if true {
-		toSerialize["description"] = o.Description
-	}
-	if true {
-		toSerialize["quantity"] = o.Quantity
-	}
-	if true {
-		toSerialize["quantity_unit"] = o.QuantityUnit
-	}
-	if true {
-		toSerialize["total"] = o.Total
-	}
-	if true {
-		toSerialize["unit_cost"] = o.UnitCost
-	}
-	return json.Marshal(toSerialize)
 }

--- a/pkg/client/model_list_allowlist_entries_response.go
+++ b/pkg/client/model_list_allowlist_entries_response.go
@@ -18,10 +18,6 @@
 
 package client
 
-import (
-	"encoding/json"
-)
-
 // ListAllowlistEntriesResponse struct for ListAllowlistEntriesResponse.
 type ListAllowlistEntriesResponse struct {
 	Allowlist   []AllowlistEntry          `json:"allowlist"`
@@ -90,18 +86,4 @@ func (o *ListAllowlistEntriesResponse) GetPropagating() bool {
 // SetPropagating sets field value.
 func (o *ListAllowlistEntriesResponse) SetPropagating(v bool) {
 	o.Propagating = v
-}
-
-func (o ListAllowlistEntriesResponse) MarshalJSON() ([]byte, error) {
-	toSerialize := map[string]interface{}{}
-	if true {
-		toSerialize["allowlist"] = o.Allowlist
-	}
-	if o.Pagination != nil {
-		toSerialize["pagination"] = o.Pagination
-	}
-	if true {
-		toSerialize["propagating"] = o.Propagating
-	}
-	return json.Marshal(toSerialize)
 }

--- a/pkg/client/model_list_available_regions_response.go
+++ b/pkg/client/model_list_available_regions_response.go
@@ -18,10 +18,6 @@
 
 package client
 
-import (
-	"encoding/json"
-)
-
 // ListAvailableRegionsResponse struct for ListAvailableRegionsResponse.
 type ListAvailableRegionsResponse struct {
 	Pagination *KeysetPaginationResponse `json:"pagination,omitempty"`
@@ -73,15 +69,4 @@ func (o *ListAvailableRegionsResponse) GetRegions() []CloudProviderRegion {
 // SetRegions sets field value.
 func (o *ListAvailableRegionsResponse) SetRegions(v []CloudProviderRegion) {
 	o.Regions = v
-}
-
-func (o ListAvailableRegionsResponse) MarshalJSON() ([]byte, error) {
-	toSerialize := map[string]interface{}{}
-	if o.Pagination != nil {
-		toSerialize["pagination"] = o.Pagination
-	}
-	if true {
-		toSerialize["regions"] = o.Regions
-	}
-	return json.Marshal(toSerialize)
 }

--- a/pkg/client/model_list_cluster_nodes_response.go
+++ b/pkg/client/model_list_cluster_nodes_response.go
@@ -18,10 +18,6 @@
 
 package client
 
-import (
-	"encoding/json"
-)
-
 // ListClusterNodesResponse struct for ListClusterNodesResponse.
 type ListClusterNodesResponse struct {
 	Nodes      []Node                    `json:"nodes"`
@@ -73,15 +69,4 @@ func (o *ListClusterNodesResponse) GetPagination() KeysetPaginationResponse {
 // SetPagination gets a reference to the given KeysetPaginationResponse and assigns it to the Pagination field.
 func (o *ListClusterNodesResponse) SetPagination(v KeysetPaginationResponse) {
 	o.Pagination = &v
-}
-
-func (o ListClusterNodesResponse) MarshalJSON() ([]byte, error) {
-	toSerialize := map[string]interface{}{}
-	if true {
-		toSerialize["nodes"] = o.Nodes
-	}
-	if o.Pagination != nil {
-		toSerialize["pagination"] = o.Pagination
-	}
-	return json.Marshal(toSerialize)
 }

--- a/pkg/client/model_list_clusters_response.go
+++ b/pkg/client/model_list_clusters_response.go
@@ -18,10 +18,6 @@
 
 package client
 
-import (
-	"encoding/json"
-)
-
 // ListClustersResponse struct for ListClustersResponse.
 type ListClustersResponse struct {
 	Clusters   []Cluster                 `json:"clusters"`
@@ -73,15 +69,4 @@ func (o *ListClustersResponse) GetPagination() KeysetPaginationResponse {
 // SetPagination gets a reference to the given KeysetPaginationResponse and assigns it to the Pagination field.
 func (o *ListClustersResponse) SetPagination(v KeysetPaginationResponse) {
 	o.Pagination = &v
-}
-
-func (o ListClustersResponse) MarshalJSON() ([]byte, error) {
-	toSerialize := map[string]interface{}{}
-	if true {
-		toSerialize["clusters"] = o.Clusters
-	}
-	if o.Pagination != nil {
-		toSerialize["pagination"] = o.Pagination
-	}
-	return json.Marshal(toSerialize)
 }

--- a/pkg/client/model_list_egress_rules_response.go
+++ b/pkg/client/model_list_egress_rules_response.go
@@ -18,10 +18,6 @@
 
 package client
 
-import (
-	"encoding/json"
-)
-
 // ListEgressRulesResponse ListEgressRulesResponse is the output for the ListEgressRules RPC..
 type ListEgressRulesResponse struct {
 	Pagination *KeysetPaginationResponse `json:"pagination,omitempty"`
@@ -64,15 +60,4 @@ func (o *ListEgressRulesResponse) GetRules() []EgressRule {
 // SetRules gets a reference to the given []EgressRule and assigns it to the Rules field.
 func (o *ListEgressRulesResponse) SetRules(v []EgressRule) {
 	o.Rules = &v
-}
-
-func (o ListEgressRulesResponse) MarshalJSON() ([]byte, error) {
-	toSerialize := map[string]interface{}{}
-	if o.Pagination != nil {
-		toSerialize["pagination"] = o.Pagination
-	}
-	if o.Rules != nil {
-		toSerialize["rules"] = o.Rules
-	}
-	return json.Marshal(toSerialize)
 }

--- a/pkg/client/model_list_invoices_response.go
+++ b/pkg/client/model_list_invoices_response.go
@@ -18,10 +18,6 @@
 
 package client
 
-import (
-	"encoding/json"
-)
-
 // ListInvoicesResponse struct for ListInvoicesResponse.
 type ListInvoicesResponse struct {
 	// invoices are sorted by period_start time.
@@ -59,12 +55,4 @@ func (o *ListInvoicesResponse) GetInvoices() []Invoice {
 // SetInvoices sets field value.
 func (o *ListInvoicesResponse) SetInvoices(v []Invoice) {
 	o.Invoices = v
-}
-
-func (o ListInvoicesResponse) MarshalJSON() ([]byte, error) {
-	toSerialize := map[string]interface{}{}
-	if true {
-		toSerialize["invoices"] = o.Invoices
-	}
-	return json.Marshal(toSerialize)
 }

--- a/pkg/client/model_list_major_cluster_versions_response.go
+++ b/pkg/client/model_list_major_cluster_versions_response.go
@@ -18,10 +18,6 @@
 
 package client
 
-import (
-	"encoding/json"
-)
-
 // ListMajorClusterVersionsResponse struct for ListMajorClusterVersionsResponse.
 type ListMajorClusterVersionsResponse struct {
 	Pagination *KeysetPaginationResponse `json:"pagination,omitempty"`
@@ -73,15 +69,4 @@ func (o *ListMajorClusterVersionsResponse) GetVersions() []ClusterMajorVersion {
 // SetVersions sets field value.
 func (o *ListMajorClusterVersionsResponse) SetVersions(v []ClusterMajorVersion) {
 	o.Versions = v
-}
-
-func (o ListMajorClusterVersionsResponse) MarshalJSON() ([]byte, error) {
-	toSerialize := map[string]interface{}{}
-	if o.Pagination != nil {
-		toSerialize["pagination"] = o.Pagination
-	}
-	if true {
-		toSerialize["versions"] = o.Versions
-	}
-	return json.Marshal(toSerialize)
 }

--- a/pkg/client/model_list_role_grants_response.go
+++ b/pkg/client/model_list_role_grants_response.go
@@ -18,10 +18,6 @@
 
 package client
 
-import (
-	"encoding/json"
-)
-
 // ListRoleGrantsResponse struct for ListRoleGrantsResponse.
 type ListRoleGrantsResponse struct {
 	Grants     *[]UserRoleGrants         `json:"grants,omitempty"`
@@ -63,15 +59,4 @@ func (o *ListRoleGrantsResponse) GetPagination() KeysetPaginationResponse {
 // SetPagination gets a reference to the given KeysetPaginationResponse and assigns it to the Pagination field.
 func (o *ListRoleGrantsResponse) SetPagination(v KeysetPaginationResponse) {
 	o.Pagination = &v
-}
-
-func (o ListRoleGrantsResponse) MarshalJSON() ([]byte, error) {
-	toSerialize := map[string]interface{}{}
-	if o.Grants != nil {
-		toSerialize["grants"] = o.Grants
-	}
-	if o.Pagination != nil {
-		toSerialize["pagination"] = o.Pagination
-	}
-	return json.Marshal(toSerialize)
 }

--- a/pkg/client/model_list_sql_users_response.go
+++ b/pkg/client/model_list_sql_users_response.go
@@ -18,10 +18,6 @@
 
 package client
 
-import (
-	"encoding/json"
-)
-
 // ListSQLUsersResponse struct for ListSQLUsersResponse.
 type ListSQLUsersResponse struct {
 	Pagination *KeysetPaginationResponse `json:"pagination,omitempty"`
@@ -73,15 +69,4 @@ func (o *ListSQLUsersResponse) GetUsers() []SQLUser {
 // SetUsers sets field value.
 func (o *ListSQLUsersResponse) SetUsers(v []SQLUser) {
 	o.Users = v
-}
-
-func (o ListSQLUsersResponse) MarshalJSON() ([]byte, error) {
-	toSerialize := map[string]interface{}{}
-	if o.Pagination != nil {
-		toSerialize["pagination"] = o.Pagination
-	}
-	if true {
-		toSerialize["users"] = o.Users
-	}
-	return json.Marshal(toSerialize)
 }

--- a/pkg/client/model_log_export_cluster_info.go
+++ b/pkg/client/model_log_export_cluster_info.go
@@ -19,7 +19,6 @@
 package client
 
 import (
-	"encoding/json"
 	"time"
 )
 
@@ -124,27 +123,4 @@ func (o *LogExportClusterInfo) GetUserMessage() string {
 // SetUserMessage gets a reference to the given string and assigns it to the UserMessage field.
 func (o *LogExportClusterInfo) SetUserMessage(v string) {
 	o.UserMessage = &v
-}
-
-func (o LogExportClusterInfo) MarshalJSON() ([]byte, error) {
-	toSerialize := map[string]interface{}{}
-	if o.ClusterId != nil {
-		toSerialize["cluster_id"] = o.ClusterId
-	}
-	if o.CreatedAt != nil {
-		toSerialize["created_at"] = o.CreatedAt
-	}
-	if o.Spec != nil {
-		toSerialize["spec"] = o.Spec
-	}
-	if o.Status != nil {
-		toSerialize["status"] = o.Status
-	}
-	if o.UpdatedAt != nil {
-		toSerialize["updated_at"] = o.UpdatedAt
-	}
-	if o.UserMessage != nil {
-		toSerialize["user_message"] = o.UserMessage
-	}
-	return json.Marshal(toSerialize)
 }

--- a/pkg/client/model_log_export_cluster_specification.go
+++ b/pkg/client/model_log_export_cluster_specification.go
@@ -18,10 +18,6 @@
 
 package client
 
-import (
-	"encoding/json"
-)
-
 // LogExportClusterSpecification LogExportClusterSpecification contains all the data necessary to configure log export for an individual cluster. Users would supply this data via the API and also receive it back when inspecting the state of their log export configuration..
 type LogExportClusterSpecification struct {
 	// auth_principal is either the AWS Role ARN that identifies a role that the cluster account can assume to write to CloudWatch or the GCP Project ID that the cluster service account has permissions to write to for cloud logging.
@@ -128,27 +124,4 @@ func (o *LogExportClusterSpecification) GetType() LogExportType {
 // SetType gets a reference to the given LogExportType and assigns it to the Type field.
 func (o *LogExportClusterSpecification) SetType(v LogExportType) {
 	o.Type = &v
-}
-
-func (o LogExportClusterSpecification) MarshalJSON() ([]byte, error) {
-	toSerialize := map[string]interface{}{}
-	if o.AuthPrincipal != nil {
-		toSerialize["auth_principal"] = o.AuthPrincipal
-	}
-	if o.Groups != nil {
-		toSerialize["groups"] = o.Groups
-	}
-	if o.LogName != nil {
-		toSerialize["log_name"] = o.LogName
-	}
-	if o.Redact != nil {
-		toSerialize["redact"] = o.Redact
-	}
-	if o.Region != nil {
-		toSerialize["region"] = o.Region
-	}
-	if o.Type != nil {
-		toSerialize["type"] = o.Type
-	}
-	return json.Marshal(toSerialize)
 }

--- a/pkg/client/model_log_export_group.go
+++ b/pkg/client/model_log_export_group.go
@@ -18,10 +18,6 @@
 
 package client
 
-import (
-	"encoding/json"
-)
-
 // LogExportGroup LogExportGroup contains an export configuration for a single log group which can route logs for a subset of CRDB channels..
 type LogExportGroup struct {
 	// channels is a list of CRDB log channels to include in this group.
@@ -108,21 +104,4 @@ func (o *LogExportGroup) GetRedact() bool {
 // SetRedact gets a reference to the given bool and assigns it to the Redact field.
 func (o *LogExportGroup) SetRedact(v bool) {
 	o.Redact = &v
-}
-
-func (o LogExportGroup) MarshalJSON() ([]byte, error) {
-	toSerialize := map[string]interface{}{}
-	if true {
-		toSerialize["channels"] = o.Channels
-	}
-	if true {
-		toSerialize["log_name"] = o.LogName
-	}
-	if o.MinLevel != nil {
-		toSerialize["min_level"] = o.MinLevel
-	}
-	if o.Redact != nil {
-		toSerialize["redact"] = o.Redact
-	}
-	return json.Marshal(toSerialize)
 }

--- a/pkg/client/model_node.go
+++ b/pkg/client/model_node.go
@@ -18,10 +18,6 @@
 
 package client
 
-import (
-	"encoding/json"
-)
-
 // Node struct for Node.
 type Node struct {
 	Name       string         `json:"name"`
@@ -92,18 +88,4 @@ func (o *Node) GetStatus() NodeStatusType {
 // SetStatus sets field value.
 func (o *Node) SetStatus(v NodeStatusType) {
 	o.Status = v
-}
-
-func (o Node) MarshalJSON() ([]byte, error) {
-	toSerialize := map[string]interface{}{}
-	if true {
-		toSerialize["name"] = o.Name
-	}
-	if true {
-		toSerialize["region_name"] = o.RegionName
-	}
-	if true {
-		toSerialize["status"] = o.Status
-	}
-	return json.Marshal(toSerialize)
 }

--- a/pkg/client/model_organization.go
+++ b/pkg/client/model_organization.go
@@ -19,7 +19,6 @@
 package client
 
 import (
-	"encoding/json"
 	"time"
 )
 
@@ -110,21 +109,4 @@ func (o *Organization) GetName() string {
 // SetName sets field value.
 func (o *Organization) SetName(v string) {
 	o.Name = v
-}
-
-func (o Organization) MarshalJSON() ([]byte, error) {
-	toSerialize := map[string]interface{}{}
-	if true {
-		toSerialize["created_at"] = o.CreatedAt
-	}
-	if true {
-		toSerialize["id"] = o.Id
-	}
-	if true {
-		toSerialize["label"] = o.Label
-	}
-	if true {
-		toSerialize["name"] = o.Name
-	}
-	return json.Marshal(toSerialize)
 }

--- a/pkg/client/model_person_user_info.go
+++ b/pkg/client/model_person_user_info.go
@@ -18,10 +18,6 @@
 
 package client
 
-import (
-	"encoding/json"
-)
-
 // PersonUserInfo struct for PersonUserInfo.
 type PersonUserInfo struct {
 	// email is an email address.
@@ -75,15 +71,4 @@ func (o *PersonUserInfo) GetId() string {
 // SetId sets field value.
 func (o *PersonUserInfo) SetId(v string) {
 	o.Id = v
-}
-
-func (o PersonUserInfo) MarshalJSON() ([]byte, error) {
-	toSerialize := map[string]interface{}{}
-	if o.Email != nil {
-		toSerialize["email"] = o.Email
-	}
-	if true {
-		toSerialize["id"] = o.Id
-	}
-	return json.Marshal(toSerialize)
 }

--- a/pkg/client/model_private_endpoint_service.go
+++ b/pkg/client/model_private_endpoint_service.go
@@ -18,10 +18,6 @@
 
 package client
 
-import (
-	"encoding/json"
-)
-
 // PrivateEndpointService struct for PrivateEndpointService.
 type PrivateEndpointService struct {
 	Aws           AWSPrivateLinkServiceDetail `json:"aws"`
@@ -110,21 +106,4 @@ func (o *PrivateEndpointService) GetStatus() PrivateEndpointServiceStatusType {
 // SetStatus sets field value.
 func (o *PrivateEndpointService) SetStatus(v PrivateEndpointServiceStatusType) {
 	o.Status = v
-}
-
-func (o PrivateEndpointService) MarshalJSON() ([]byte, error) {
-	toSerialize := map[string]interface{}{}
-	if true {
-		toSerialize["aws"] = o.Aws
-	}
-	if true {
-		toSerialize["cloud_provider"] = o.CloudProvider
-	}
-	if true {
-		toSerialize["region_name"] = o.RegionName
-	}
-	if true {
-		toSerialize["status"] = o.Status
-	}
-	return json.Marshal(toSerialize)
 }

--- a/pkg/client/model_private_endpoint_services.go
+++ b/pkg/client/model_private_endpoint_services.go
@@ -18,10 +18,6 @@
 
 package client
 
-import (
-	"encoding/json"
-)
-
 // PrivateEndpointServices struct for PrivateEndpointServices.
 type PrivateEndpointServices struct {
 	// services contains a list of all cluster related services.
@@ -59,12 +55,4 @@ func (o *PrivateEndpointServices) GetServices() []PrivateEndpointService {
 // SetServices sets field value.
 func (o *PrivateEndpointServices) SetServices(v []PrivateEndpointService) {
 	o.Services = v
-}
-
-func (o PrivateEndpointServices) MarshalJSON() ([]byte, error) {
-	toSerialize := map[string]interface{}{}
-	if true {
-		toSerialize["services"] = o.Services
-	}
-	return json.Marshal(toSerialize)
 }

--- a/pkg/client/model_region.go
+++ b/pkg/client/model_region.go
@@ -18,10 +18,6 @@
 
 package client
 
-import (
-	"encoding/json"
-)
-
 // Region struct for Region.
 type Region struct {
 	// internal_dns is the internal DNS name of the cluster within the cloud provider's network. It is used to connect to the cluster with PrivateLink or VPC peering.
@@ -146,27 +142,4 @@ func (o *Region) GetUiDns() string {
 // SetUiDns sets field value.
 func (o *Region) SetUiDns(v string) {
 	o.UiDns = v
-}
-
-func (o Region) MarshalJSON() ([]byte, error) {
-	toSerialize := map[string]interface{}{}
-	if true {
-		toSerialize["internal_dns"] = o.InternalDns
-	}
-	if true {
-		toSerialize["name"] = o.Name
-	}
-	if true {
-		toSerialize["node_count"] = o.NodeCount
-	}
-	if o.Primary != nil {
-		toSerialize["primary"] = o.Primary
-	}
-	if true {
-		toSerialize["sql_dns"] = o.SqlDns
-	}
-	if true {
-		toSerialize["ui_dns"] = o.UiDns
-	}
-	return json.Marshal(toSerialize)
 }

--- a/pkg/client/model_resource.go
+++ b/pkg/client/model_resource.go
@@ -18,10 +18,6 @@
 
 package client
 
-import (
-	"encoding/json"
-)
-
 // Resource struct for Resource.
 type Resource struct {
 	Id   *string          `json:"id,omitempty"`
@@ -73,15 +69,4 @@ func (o *Resource) GetType() ResourceTypeType {
 // SetType sets field value.
 func (o *Resource) SetType(v ResourceTypeType) {
 	o.Type = v
-}
-
-func (o Resource) MarshalJSON() ([]byte, error) {
-	toSerialize := map[string]interface{}{}
-	if o.Id != nil {
-		toSerialize["id"] = o.Id
-	}
-	if true {
-		toSerialize["type"] = o.Type
-	}
-	return json.Marshal(toSerialize)
 }

--- a/pkg/client/model_serverless_cluster_config.go
+++ b/pkg/client/model_serverless_cluster_config.go
@@ -18,10 +18,6 @@
 
 package client
 
-import (
-	"encoding/json"
-)
-
 // ServerlessClusterConfig struct for ServerlessClusterConfig.
 type ServerlessClusterConfig struct {
 	// routing_id is used to identify the cluster in a connection string.
@@ -90,18 +86,4 @@ func (o *ServerlessClusterConfig) GetUsageLimits() UsageLimits {
 // SetUsageLimits gets a reference to the given UsageLimits and assigns it to the UsageLimits field.
 func (o *ServerlessClusterConfig) SetUsageLimits(v UsageLimits) {
 	o.UsageLimits = &v
-}
-
-func (o ServerlessClusterConfig) MarshalJSON() ([]byte, error) {
-	toSerialize := map[string]interface{}{}
-	if true {
-		toSerialize["routing_id"] = o.RoutingId
-	}
-	if o.SpendLimit != nil {
-		toSerialize["spend_limit"] = o.SpendLimit
-	}
-	if o.UsageLimits != nil {
-		toSerialize["usage_limits"] = o.UsageLimits
-	}
-	return json.Marshal(toSerialize)
 }

--- a/pkg/client/model_serverless_cluster_create_specification.go
+++ b/pkg/client/model_serverless_cluster_create_specification.go
@@ -18,10 +18,6 @@
 
 package client
 
-import (
-	"encoding/json"
-)
-
 // ServerlessClusterCreateSpecification struct for ServerlessClusterCreateSpecification.
 type ServerlessClusterCreateSpecification struct {
 	// Preview: Specify which region should be made the primary region. This is only applicable to multi-region Serverless clusters. This field is required if you create the cluster in more than one region.
@@ -106,21 +102,4 @@ func (o *ServerlessClusterCreateSpecification) GetUsageLimits() UsageLimits {
 // SetUsageLimits gets a reference to the given UsageLimits and assigns it to the UsageLimits field.
 func (o *ServerlessClusterCreateSpecification) SetUsageLimits(v UsageLimits) {
 	o.UsageLimits = &v
-}
-
-func (o ServerlessClusterCreateSpecification) MarshalJSON() ([]byte, error) {
-	toSerialize := map[string]interface{}{}
-	if o.PrimaryRegion != nil {
-		toSerialize["primary_region"] = o.PrimaryRegion
-	}
-	if true {
-		toSerialize["regions"] = o.Regions
-	}
-	if o.SpendLimit != nil {
-		toSerialize["spend_limit"] = o.SpendLimit
-	}
-	if o.UsageLimits != nil {
-		toSerialize["usage_limits"] = o.UsageLimits
-	}
-	return json.Marshal(toSerialize)
 }

--- a/pkg/client/model_serverless_cluster_update_specification.go
+++ b/pkg/client/model_serverless_cluster_update_specification.go
@@ -18,10 +18,6 @@
 
 package client
 
-import (
-	"encoding/json"
-)
-
 // ServerlessClusterUpdateSpecification struct for ServerlessClusterUpdateSpecification.
 type ServerlessClusterUpdateSpecification struct {
 	// spend_limit is the maximum monthly charge for a cluster, in US cents. We recommend using usage_limits instead, since spend_limit will be deprecated in the future.
@@ -64,15 +60,4 @@ func (o *ServerlessClusterUpdateSpecification) GetUsageLimits() UsageLimits {
 // SetUsageLimits gets a reference to the given UsageLimits and assigns it to the UsageLimits field.
 func (o *ServerlessClusterUpdateSpecification) SetUsageLimits(v UsageLimits) {
 	o.UsageLimits = &v
-}
-
-func (o ServerlessClusterUpdateSpecification) MarshalJSON() ([]byte, error) {
-	toSerialize := map[string]interface{}{}
-	if o.SpendLimit != nil {
-		toSerialize["spend_limit"] = o.SpendLimit
-	}
-	if o.UsageLimits != nil {
-		toSerialize["usage_limits"] = o.UsageLimits
-	}
-	return json.Marshal(toSerialize)
 }

--- a/pkg/client/model_set_aws_endpoint_connection_state_request.go
+++ b/pkg/client/model_set_aws_endpoint_connection_state_request.go
@@ -18,10 +18,6 @@
 
 package client
 
-import (
-	"encoding/json"
-)
-
 // SetAwsEndpointConnectionStateRequest struct for SetAwsEndpointConnectionStateRequest.
 type SetAwsEndpointConnectionStateRequest struct {
 	Status SetAWSEndpointConnectionStatusType `json:"status"`
@@ -58,12 +54,4 @@ func (o *SetAwsEndpointConnectionStateRequest) GetStatus() SetAWSEndpointConnect
 // SetStatus sets field value.
 func (o *SetAwsEndpointConnectionStateRequest) SetStatus(v SetAWSEndpointConnectionStatusType) {
 	o.Status = v
-}
-
-func (o SetAwsEndpointConnectionStateRequest) MarshalJSON() ([]byte, error) {
-	toSerialize := map[string]interface{}{}
-	if true {
-		toSerialize["status"] = o.Status
-	}
-	return json.Marshal(toSerialize)
 }

--- a/pkg/client/model_set_client_ca_cert_request.go
+++ b/pkg/client/model_set_client_ca_cert_request.go
@@ -18,10 +18,6 @@
 
 package client
 
-import (
-	"encoding/json"
-)
-
 // SetClientCACertRequest struct for SetClientCACertRequest.
 type SetClientCACertRequest struct {
 	X509PemCert string `json:"x509_pem_cert"`
@@ -58,12 +54,4 @@ func (o *SetClientCACertRequest) GetX509PemCert() string {
 // SetX509PemCert sets field value.
 func (o *SetClientCACertRequest) SetX509PemCert(v string) {
 	o.X509PemCert = v
-}
-
-func (o SetClientCACertRequest) MarshalJSON() ([]byte, error) {
-	toSerialize := map[string]interface{}{}
-	if true {
-		toSerialize["x509_pem_cert"] = o.X509PemCert
-	}
-	return json.Marshal(toSerialize)
 }

--- a/pkg/client/model_set_egress_traffic_policy_request.go
+++ b/pkg/client/model_set_egress_traffic_policy_request.go
@@ -18,10 +18,6 @@
 
 package client
 
-import (
-	"encoding/json"
-)
-
 // SetEgressTrafficPolicyRequest SetEgressTrafficPolicyRequest is the input for the SetEgressTrafficPolicy RPC..
 type SetEgressTrafficPolicyRequest struct {
 	// allow_all, if true results in unrestricted egress traffic. If false, egress traffic is set to default-deny and is managed via the Egress Rule Management API.
@@ -75,15 +71,4 @@ func (o *SetEgressTrafficPolicyRequest) GetIdempotencyKey() string {
 // SetIdempotencyKey gets a reference to the given string and assigns it to the IdempotencyKey field.
 func (o *SetEgressTrafficPolicyRequest) SetIdempotencyKey(v string) {
 	o.IdempotencyKey = &v
-}
-
-func (o SetEgressTrafficPolicyRequest) MarshalJSON() ([]byte, error) {
-	toSerialize := map[string]interface{}{}
-	if true {
-		toSerialize["allow_all"] = o.AllowAll
-	}
-	if o.IdempotencyKey != nil {
-		toSerialize["idempotency_key"] = o.IdempotencyKey
-	}
-	return json.Marshal(toSerialize)
 }

--- a/pkg/client/model_sql_user.go
+++ b/pkg/client/model_sql_user.go
@@ -18,10 +18,6 @@
 
 package client
 
-import (
-	"encoding/json"
-)
-
 // SQLUser struct for SQLUser.
 type SQLUser struct {
 	Name string `json:"name"`
@@ -58,12 +54,4 @@ func (o *SQLUser) GetName() string {
 // SetName sets field value.
 func (o *SQLUser) SetName(v string) {
 	o.Name = v
-}
-
-func (o SQLUser) MarshalJSON() ([]byte, error) {
-	toSerialize := map[string]interface{}{}
-	if true {
-		toSerialize["name"] = o.Name
-	}
-	return json.Marshal(toSerialize)
 }

--- a/pkg/client/model_status.go
+++ b/pkg/client/model_status.go
@@ -18,10 +18,6 @@
 
 package client
 
-import (
-	"encoding/json"
-)
-
 // Status struct for Status.
 type Status struct {
 	Code    *int32  `json:"code,omitempty"`
@@ -78,18 +74,4 @@ func (o *Status) GetMessage() string {
 // SetMessage gets a reference to the given string and assigns it to the Message field.
 func (o *Status) SetMessage(v string) {
 	o.Message = &v
-}
-
-func (o Status) MarshalJSON() ([]byte, error) {
-	toSerialize := map[string]interface{}{}
-	if o.Code != nil {
-		toSerialize["code"] = o.Code
-	}
-	if o.Details != nil {
-		toSerialize["details"] = o.Details
-	}
-	if o.Message != nil {
-		toSerialize["message"] = o.Message
-	}
-	return json.Marshal(toSerialize)
 }

--- a/pkg/client/model_update_client_ca_cert_request.go
+++ b/pkg/client/model_update_client_ca_cert_request.go
@@ -18,10 +18,6 @@
 
 package client
 
-import (
-	"encoding/json"
-)
-
 // UpdateClientCACertRequest struct for UpdateClientCACertRequest.
 type UpdateClientCACertRequest struct {
 	X509PemCert *string `json:"x509_pem_cert,omitempty"`
@@ -48,12 +44,4 @@ func (o *UpdateClientCACertRequest) GetX509PemCert() string {
 // SetX509PemCert gets a reference to the given string and assigns it to the X509PemCert field.
 func (o *UpdateClientCACertRequest) SetX509PemCert(v string) {
 	o.X509PemCert = &v
-}
-
-func (o UpdateClientCACertRequest) MarshalJSON() ([]byte, error) {
-	toSerialize := map[string]interface{}{}
-	if o.X509PemCert != nil {
-		toSerialize["x509_pem_cert"] = o.X509PemCert
-	}
-	return json.Marshal(toSerialize)
 }

--- a/pkg/client/model_update_cluster_specification.go
+++ b/pkg/client/model_update_cluster_specification.go
@@ -18,10 +18,6 @@
 
 package client
 
-import (
-	"encoding/json"
-)
-
 // UpdateClusterSpecification Set `upgrade_status` to 'UPGRADE_RUNNING' to start an upgrade. Multi-node clusters will undergo a rolling upgrade and will remain available, but single-node clusters will be briefly unavailable while the upgrade takes place. Upgrades will be finalized automatically after 72 hours, or can be manually finalized by setting the value to 'FINALIZED'. Before the cluster is finalized, it can be rolled back by setting the value to 'ROLLBACK_RUNNING'. Version upgrade operations cannot be performed simultaneously with other update operations..
 type UpdateClusterSpecification struct {
 	Dedicated     *DedicatedClusterUpdateSpecification  `json:"dedicated,omitempty"`
@@ -78,18 +74,4 @@ func (o *UpdateClusterSpecification) GetUpgradeStatus() ClusterUpgradeStatusType
 // SetUpgradeStatus gets a reference to the given ClusterUpgradeStatusType and assigns it to the UpgradeStatus field.
 func (o *UpdateClusterSpecification) SetUpgradeStatus(v ClusterUpgradeStatusType) {
 	o.UpgradeStatus = &v
-}
-
-func (o UpdateClusterSpecification) MarshalJSON() ([]byte, error) {
-	toSerialize := map[string]interface{}{}
-	if o.Dedicated != nil {
-		toSerialize["dedicated"] = o.Dedicated
-	}
-	if o.Serverless != nil {
-		toSerialize["serverless"] = o.Serverless
-	}
-	if o.UpgradeStatus != nil {
-		toSerialize["upgrade_status"] = o.UpgradeStatus
-	}
-	return json.Marshal(toSerialize)
 }

--- a/pkg/client/model_update_cmek_status_request.go
+++ b/pkg/client/model_update_cmek_status_request.go
@@ -18,10 +18,6 @@
 
 package client
 
-import (
-	"encoding/json"
-)
-
 // UpdateCMEKStatusRequest struct for UpdateCMEKStatusRequest.
 type UpdateCMEKStatusRequest struct {
 	Action CMEKCustomerAction `json:"action"`
@@ -58,12 +54,4 @@ func (o *UpdateCMEKStatusRequest) GetAction() CMEKCustomerAction {
 // SetAction sets field value.
 func (o *UpdateCMEKStatusRequest) SetAction(v CMEKCustomerAction) {
 	o.Action = v
-}
-
-func (o UpdateCMEKStatusRequest) MarshalJSON() ([]byte, error) {
-	toSerialize := map[string]interface{}{}
-	if true {
-		toSerialize["action"] = o.Action
-	}
-	return json.Marshal(toSerialize)
 }

--- a/pkg/client/model_update_database_request.go
+++ b/pkg/client/model_update_database_request.go
@@ -18,10 +18,6 @@
 
 package client
 
-import (
-	"encoding/json"
-)
-
 // UpdateDatabaseRequest struct for UpdateDatabaseRequest.
 type UpdateDatabaseRequest struct {
 	Name    string `json:"name"`
@@ -75,15 +71,4 @@ func (o *UpdateDatabaseRequest) GetNewName() string {
 // SetNewName sets field value.
 func (o *UpdateDatabaseRequest) SetNewName(v string) {
 	o.NewName = v
-}
-
-func (o UpdateDatabaseRequest) MarshalJSON() ([]byte, error) {
-	toSerialize := map[string]interface{}{}
-	if true {
-		toSerialize["name"] = o.Name
-	}
-	if true {
-		toSerialize["new_name"] = o.NewName
-	}
-	return json.Marshal(toSerialize)
 }

--- a/pkg/client/model_update_database_request_1.go
+++ b/pkg/client/model_update_database_request_1.go
@@ -18,10 +18,6 @@
 
 package client
 
-import (
-	"encoding/json"
-)
-
 // UpdateDatabaseRequest1 struct for UpdateDatabaseRequest1.
 type UpdateDatabaseRequest1 struct {
 	NewName string `json:"new_name"`
@@ -58,12 +54,4 @@ func (o *UpdateDatabaseRequest1) GetNewName() string {
 // SetNewName sets field value.
 func (o *UpdateDatabaseRequest1) SetNewName(v string) {
 	o.NewName = v
-}
-
-func (o UpdateDatabaseRequest1) MarshalJSON() ([]byte, error) {
-	toSerialize := map[string]interface{}{}
-	if true {
-		toSerialize["new_name"] = o.NewName
-	}
-	return json.Marshal(toSerialize)
 }

--- a/pkg/client/model_update_sql_user_password_request.go
+++ b/pkg/client/model_update_sql_user_password_request.go
@@ -18,10 +18,6 @@
 
 package client
 
-import (
-	"encoding/json"
-)
-
 // UpdateSQLUserPasswordRequest struct for UpdateSQLUserPasswordRequest.
 type UpdateSQLUserPasswordRequest struct {
 	Password string `json:"password"`
@@ -58,12 +54,4 @@ func (o *UpdateSQLUserPasswordRequest) GetPassword() string {
 // SetPassword sets field value.
 func (o *UpdateSQLUserPasswordRequest) SetPassword(v string) {
 	o.Password = v
-}
-
-func (o UpdateSQLUserPasswordRequest) MarshalJSON() ([]byte, error) {
-	toSerialize := map[string]interface{}{}
-	if true {
-		toSerialize["password"] = o.Password
-	}
-	return json.Marshal(toSerialize)
 }

--- a/pkg/client/model_usage_limits.go
+++ b/pkg/client/model_usage_limits.go
@@ -18,10 +18,6 @@
 
 package client
 
-import (
-	"encoding/json"
-)
-
 // UsageLimits struct for UsageLimits.
 type UsageLimits struct {
 	// request_unit_limit is the maximum number of request units that the cluster can consume during the month. If this limit is exceeded, then the cluster is disabled until the limit is increased, or until the beginning of the next month when more free request units are granted. It is an error for this to be zero.
@@ -77,15 +73,4 @@ func (o *UsageLimits) GetStorageMibLimit() int64 {
 // SetStorageMibLimit sets field value.
 func (o *UsageLimits) SetStorageMibLimit(v int64) {
 	o.StorageMibLimit = v
-}
-
-func (o UsageLimits) MarshalJSON() ([]byte, error) {
-	toSerialize := map[string]interface{}{}
-	if true {
-		toSerialize["request_unit_limit"] = o.RequestUnitLimit
-	}
-	if true {
-		toSerialize["storage_mib_limit"] = o.StorageMibLimit
-	}
-	return json.Marshal(toSerialize)
 }

--- a/pkg/client/model_user_role_grants.go
+++ b/pkg/client/model_user_role_grants.go
@@ -18,10 +18,6 @@
 
 package client
 
-import (
-	"encoding/json"
-)
-
 // UserRoleGrants struct for UserRoleGrants.
 type UserRoleGrants struct {
 	Roles  []BuiltInRole `json:"roles"`
@@ -75,15 +71,4 @@ func (o *UserRoleGrants) GetUserId() string {
 // SetUserId sets field value.
 func (o *UserRoleGrants) SetUserId(v string) {
 	o.UserId = v
-}
-
-func (o UserRoleGrants) MarshalJSON() ([]byte, error) {
-	toSerialize := map[string]interface{}{}
-	if true {
-		toSerialize["roles"] = o.Roles
-	}
-	if true {
-		toSerialize["user_id"] = o.UserId
-	}
-	return json.Marshal(toSerialize)
 }


### PR DESCRIPTION
The OpenAPI generator generates a custom MarshalJSON method for each model. The generated code adds each model field into a map, and then marshals the map using the default JSON marshalling code. However, this generated code doesn't respect JSON field attributes like "string", which are meant to modify marshalling behavior. This issue is preventing the SDK from round- tripping certain models: the UnmarshalJSON method is not overridden and does respect JSON field attributes, while the MarshalJSON method does not respect them. This is causing errors in the ccloud tool, which expects all fields to be round-trippable.

The fix for this problem is to stop generating custom MarshalJSON methods, so that the default JSON marshalling will run instead. It doesn't seem like the custom marshalling code is doing anything special (at least not for the models we use), so it should be safe to skip it.