### PR TITLE
add support for editing serverless regions

### DIFF
--- a/docs/AuditLogsApi.md
+++ b/docs/AuditLogsApi.md
@@ -13,7 +13,7 @@ Method | HTTP request | Description
 > ListAuditLogsResponse ListAuditLogs(ctx).StartingFrom(startingFrom).SortOrder(sortOrder).Limit(limit).Execute()
 
 List audit logs
-    
+
 Can be used by the following roles assigned at the organization scope:
 - ORG_ADMIN
 

--- a/docs/BillingApi.md
+++ b/docs/BillingApi.md
@@ -14,7 +14,7 @@ Method | HTTP request | Description
 > Invoice GetInvoice(ctx, invoiceId).Execute()
 
 Get a specific invoice for an organization
-    
+
 Can be used by the following roles assigned at the organization scope:
 - BILLING_COORDINATOR
 - CLUSTER_ADMIN
@@ -86,7 +86,7 @@ Name | Type | Description  | Notes
 > ListInvoicesResponse ListInvoices(ctx).Execute()
 
 List invoices for a given organization
-    
+
 Can be used by the following roles assigned at the organization scope:
 - BILLING_COORDINATOR
 - CLUSTER_ADMIN

--- a/docs/ClientCACertificatesApi.md
+++ b/docs/ClientCACertificatesApi.md
@@ -16,7 +16,7 @@ Method | HTTP request | Description
 > ClientCACertInfo DeleteClientCACert(ctx, clusterId).Execute()
 
 Delete Client CA Cert for a cluster
-    
+
 Can be used by the following roles assigned at the organization or cluster scope:
 - CLUSTER_ADMIN
 - CLUSTER_OPERATOR_WRITER
@@ -88,7 +88,7 @@ Name | Type | Description  | Notes
 > ClientCACertInfo GetClientCACert(ctx, clusterId).Execute()
 
 Get Client CA Cert information for a cluster
-    
+
 Can be used by the following roles assigned at the organization or cluster scope:
 - CLUSTER_ADMIN
 - CLUSTER_OPERATOR_WRITER
@@ -160,7 +160,7 @@ Name | Type | Description  | Notes
 > ClientCACertInfo SetClientCACert(ctx, clusterId).SetClientCACertRequest(setClientCACertRequest).Execute()
 
 Set Client CA Cert for a cluster
-    
+
 Can be used by the following roles assigned at the organization or cluster scope:
 - CLUSTER_ADMIN
 - CLUSTER_OPERATOR_WRITER
@@ -234,7 +234,7 @@ Name | Type | Description  | Notes
 > ClientCACertInfo UpdateClientCACert(ctx, clusterId).UpdateClientCACertRequest(updateClientCACertRequest).Execute()
 
 Update Client CA Cert for a cluster
-    
+
 Can be used by the following roles assigned at the organization or cluster scope:
 - CLUSTER_ADMIN
 - CLUSTER_OPERATOR_WRITER

--- a/docs/ClustersApi.md
+++ b/docs/ClustersApi.md
@@ -21,7 +21,7 @@ Method | HTTP request | Description
 > Cluster CreateCluster(ctx).CreateClusterRequest(createClusterRequest).Execute()
 
 Create and initialize a new cluster
-    
+
 Can be used by the following roles assigned at the organization scope:
 - CLUSTER_ADMIN
 - CLUSTER_CREATOR
@@ -89,7 +89,7 @@ Name | Type | Description  | Notes
 > Cluster DeleteCluster(ctx, clusterId).Execute()
 
 Delete a cluster and all of its data
-    
+
 Can be used by the following roles assigned at the organization or cluster scope:
 - CLUSTER_ADMIN
 
@@ -160,7 +160,7 @@ Name | Type | Description  | Notes
 > Cluster GetCluster(ctx, clusterId).Execute()
 
 Get extended information about a cluster
-    
+
 Can be used by the following roles assigned at the organization or cluster scope:
 - ORG_ADMIN
 - CLUSTER_ADMIN
@@ -234,7 +234,7 @@ Name | Type | Description  | Notes
 > GetConnectionStringResponse GetConnectionString(ctx, clusterId).Database(database).SqlUser(sqlUser).Os(os).Execute()
 
 Get a formatted generic connection string for a cluster
-    
+
 Can be used by the following roles assigned at the organization or cluster scope:
 - ORG_ADMIN
 - CLUSTER_ADMIN
@@ -314,7 +314,7 @@ Name | Type | Description  | Notes
 > ListAvailableRegionsResponse ListAvailableRegions(ctx).Provider(provider).Serverless(serverless).PaginationPage(paginationPage).PaginationLimit(paginationLimit).PaginationAsOfTime(paginationAsOfTime).PaginationSortOrder(paginationSortOrder).Execute()
 
 List the regions available for new clusters and nodes
-    
+
 This endpoint may be used by any member of the organization.
 
 ### Example
@@ -390,7 +390,7 @@ Name | Type | Description  | Notes
 > ListClusterNodesResponse ListClusterNodes(ctx, clusterId).RegionName(regionName).PaginationPage(paginationPage).PaginationLimit(paginationLimit).PaginationAsOfTime(paginationAsOfTime).PaginationSortOrder(paginationSortOrder).Execute()
 
 List nodes for a cluster
-    
+
 Can be used by the following roles assigned at the organization or cluster scope:
 - ORG_ADMIN
 - CLUSTER_ADMIN
@@ -475,7 +475,7 @@ Name | Type | Description  | Notes
 > ListClustersResponse ListClusters(ctx).ShowInactive(showInactive).PaginationPage(paginationPage).PaginationLimit(paginationLimit).PaginationAsOfTime(paginationAsOfTime).PaginationSortOrder(paginationSortOrder).Execute()
 
 List clusters owned by an organization
-    
+
 Returns all clusters that the user has read access over
 
 ### Example
@@ -549,7 +549,7 @@ Name | Type | Description  | Notes
 > ListMajorClusterVersionsResponse ListMajorClusterVersions(ctx).PaginationPage(paginationPage).PaginationLimit(paginationLimit).PaginationAsOfTime(paginationAsOfTime).PaginationSortOrder(paginationSortOrder).Execute()
 
 List available major cluster versions
-    
+
 This endpoint may be used by any member of the organization.
 
 ### Example
@@ -621,7 +621,7 @@ Name | Type | Description  | Notes
 > Cluster UpdateCluster(ctx, clusterId).UpdateClusterSpecification(updateClusterSpecification).Execute()
 
 Scale or edit a cluster
-    
+
 Can be used by the following roles assigned at the organization or cluster scope:
 - CLUSTER_ADMIN
 - CLUSTER_OPERATOR_WRITER

--- a/docs/CustomerManagedEncryptionKeysApi.md
+++ b/docs/CustomerManagedEncryptionKeysApi.md
@@ -16,7 +16,7 @@ Method | HTTP request | Description
 > CMEKClusterInfo EnableCMEKSpec(ctx, clusterId).CMEKClusterSpecification(cMEKClusterSpecification).Execute()
 
 Enable CMEK for a cluster
-    
+
 Can be used by the following roles assigned at the organization or cluster scope:
 - CLUSTER_ADMIN
 - CLUSTER_OPERATOR_WRITER
@@ -90,7 +90,7 @@ Name | Type | Description  | Notes
 > CMEKClusterInfo GetCMEKClusterInfo(ctx, clusterId).Execute()
 
 Get CMEK-related information for a cluster
-    
+
 Can be used by the following roles assigned at the organization or cluster scope:
 - CLUSTER_ADMIN
 - CLUSTER_OPERATOR_WRITER
@@ -162,7 +162,7 @@ Name | Type | Description  | Notes
 > CMEKClusterInfo UpdateCMEKSpec(ctx, clusterId).CMEKClusterSpecification(cMEKClusterSpecification).Execute()
 
 Enable or update the CMEK spec for a cluster
-    
+
 Can be used by the following roles assigned at the organization or cluster scope:
 - CLUSTER_ADMIN
 - CLUSTER_OPERATOR_WRITER
@@ -236,7 +236,7 @@ Name | Type | Description  | Notes
 > CMEKClusterInfo UpdateCMEKStatus(ctx, clusterId).UpdateCMEKStatusRequest(updateCMEKStatusRequest).Execute()
 
 Update the CMEK-related status for a cluster
-    
+
 Can be used by the following roles assigned at the organization or cluster scope:
 - CLUSTER_ADMIN
 - CLUSTER_OPERATOR_WRITER

--- a/docs/DatabasesApi.md
+++ b/docs/DatabasesApi.md
@@ -17,7 +17,7 @@ Method | HTTP request | Description
 > ApiDatabase CreateDatabase(ctx, clusterId).CreateDatabaseRequest(createDatabaseRequest).Execute()
 
 Create a new database
-    
+
 Can be used by the following roles assigned at the organization or cluster scope:
 - CLUSTER_ADMIN
 - CLUSTER_OPERATOR_WRITER
@@ -91,7 +91,7 @@ Name | Type | Description  | Notes
 > ApiDatabase DeleteDatabase(ctx, clusterId, name).Execute()
 
 Delete a database
-    
+
 Can be used by the following roles assigned at the organization or cluster scope:
 - CLUSTER_ADMIN
 - CLUSTER_OPERATOR_WRITER
@@ -166,7 +166,7 @@ Name | Type | Description  | Notes
 > ApiDatabase EditDatabase(ctx, clusterId, name).UpdateDatabaseRequest1(updateDatabaseRequest1).Execute()
 
 Update a database
-    
+
 Can be used by the following roles assigned at the organization or cluster scope:
 - CLUSTER_ADMIN
 - CLUSTER_OPERATOR_WRITER
@@ -243,7 +243,7 @@ Name | Type | Description  | Notes
 > ApiDatabase EditDatabase2(ctx, clusterId).UpdateDatabaseRequest(updateDatabaseRequest).Execute()
 
 Update a database
-    
+
 Can be used by the following roles assigned at the organization or cluster scope:
 - CLUSTER_ADMIN
 - CLUSTER_OPERATOR_WRITER
@@ -317,7 +317,7 @@ Name | Type | Description  | Notes
 > ApiListDatabasesResponse ListDatabases(ctx, clusterId).PaginationPage(paginationPage).PaginationLimit(paginationLimit).PaginationAsOfTime(paginationAsOfTime).PaginationSortOrder(paginationSortOrder).Execute()
 
 List databases for a cluster
-    
+
 Can be used by the following roles assigned at the organization or cluster scope:
 - CLUSTER_ADMIN
 - CLUSTER_OPERATOR_WRITER

--- a/docs/EgressRulesApi.md
+++ b/docs/EgressRulesApi.md
@@ -18,7 +18,7 @@ Method | HTTP request | Description
 > AddEgressRuleResponse AddEgressRule(ctx, clusterId).AddEgressRuleRequest(addEgressRuleRequest).Execute()
 
 Add an egress rule
-    
+
 Can be used by the following roles assigned at the organization or cluster scope:
 - CLUSTER_ADMIN
 - CLUSTER_OPERATOR_WRITER
@@ -92,7 +92,7 @@ Name | Type | Description  | Notes
 > DeleteEgressRuleResponse DeleteEgressRule(ctx, clusterId, ruleId).IdempotencyKey(idempotencyKey).Execute()
 
 Delete an existing egress rule
-    
+
 Can be used by the following roles assigned at the organization or cluster scope:
 - CLUSTER_ADMIN
 - CLUSTER_OPERATOR_WRITER
@@ -169,7 +169,7 @@ Name | Type | Description  | Notes
 > EditEgressRuleResponse EditEgressRule(ctx, clusterId, ruleId).EditEgressRuleRequest(editEgressRuleRequest).Execute()
 
 Edit an existing egress rule
-    
+
 Can be used by the following roles assigned at the organization or cluster scope:
 - CLUSTER_ADMIN
 - CLUSTER_OPERATOR_WRITER
@@ -246,7 +246,7 @@ Name | Type | Description  | Notes
 > GetEgressRuleResponse GetEgressRule(ctx, clusterId, ruleId).Execute()
 
 Get an existing egress rule
-    
+
 Can be used by the following roles assigned at the organization or cluster scope:
 - CLUSTER_ADMIN
 - CLUSTER_OPERATOR_WRITER
@@ -321,7 +321,7 @@ Name | Type | Description  | Notes
 > ListEgressRulesResponse ListEgressRules(ctx, clusterId).PaginationPage(paginationPage).PaginationLimit(paginationLimit).PaginationAsOfTime(paginationAsOfTime).PaginationSortOrder(paginationSortOrder).Execute()
 
 List all egress rules associates with a cluster
-    
+
 Can be used by the following roles assigned at the organization or cluster scope:
 - CLUSTER_ADMIN
 - CLUSTER_OPERATOR_WRITER
@@ -402,7 +402,7 @@ Name | Type | Description  | Notes
 > map[string]interface{} SetEgressTrafficPolicy(ctx, clusterId).SetEgressTrafficPolicyRequest(setEgressTrafficPolicyRequest).Execute()
 
 Outbound traffic management
-    
+
 Can be used by the following roles assigned at the organization or cluster scope:
 - CLUSTER_ADMIN
 - CLUSTER_OPERATOR_WRITER

--- a/docs/IPAllowlistsApi.md
+++ b/docs/IPAllowlistsApi.md
@@ -17,7 +17,7 @@ Method | HTTP request | Description
 > AllowlistEntry AddAllowlistEntry(ctx, clusterId).AllowlistEntry(allowlistEntry).Execute()
 
 Add a new CIDR address to the IP allowlist
-    
+
 Can be used by the following roles assigned at the organization or cluster scope:
 - CLUSTER_ADMIN
 - CLUSTER_OPERATOR_WRITER
@@ -91,7 +91,7 @@ Name | Type | Description  | Notes
 > AllowlistEntry AddAllowlistEntry2(ctx, clusterId, entryCidrIp, entryCidrMask).AllowlistEntry1(allowlistEntry1).Execute()
 
 Add a new CIDR address to the IP allowlist
-    
+
 Can be used by the following roles assigned at the organization or cluster scope:
 - CLUSTER_ADMIN
 - CLUSTER_OPERATOR_WRITER
@@ -171,7 +171,7 @@ Name | Type | Description  | Notes
 > AllowlistEntry DeleteAllowlistEntry(ctx, clusterId, cidrIp, cidrMask).Execute()
 
 Delete an IP allowlist entry
-    
+
 Can be used by the following roles assigned at the organization or cluster scope:
 - CLUSTER_ADMIN
 - CLUSTER_OPERATOR_WRITER
@@ -249,7 +249,7 @@ Name | Type | Description  | Notes
 > ListAllowlistEntriesResponse ListAllowlistEntries(ctx, clusterId).PaginationPage(paginationPage).PaginationLimit(paginationLimit).PaginationAsOfTime(paginationAsOfTime).PaginationSortOrder(paginationSortOrder).Execute()
 
 Get the IP allowlist and propagation status for a cluster
-    
+
 Can be used by the following roles assigned at the organization or cluster scope:
 - CLUSTER_ADMIN
 - CLUSTER_OPERATOR_WRITER
@@ -331,7 +331,7 @@ Name | Type | Description  | Notes
 > AllowlistEntry UpdateAllowlistEntry(ctx, clusterId, entryCidrIp, entryCidrMask).AllowlistEntry1(allowlistEntry1).Execute()
 
 Update an IP allowlist entry
-    
+
 Can be used by the following roles assigned at the organization or cluster scope:
 - CLUSTER_ADMIN
 - CLUSTER_OPERATOR_WRITER

--- a/docs/LogExportApi.md
+++ b/docs/LogExportApi.md
@@ -15,7 +15,7 @@ Method | HTTP request | Description
 > LogExportClusterInfo DeleteLogExport(ctx, clusterId).Execute()
 
 Delete the Log Export configuration for a cluster
-    
+
 Can be used by the following roles assigned at the organization or cluster scope:
 - ORG_ADMIN
 
@@ -86,7 +86,7 @@ Name | Type | Description  | Notes
 > LogExportClusterInfo EnableLogExport(ctx, clusterId).EnableLogExportRequest(enableLogExportRequest).Execute()
 
 Create or update the Log Export configuration for a cluster
-    
+
 Can be used by the following roles assigned at the organization or cluster scope:
 - ORG_ADMIN
 
@@ -159,7 +159,7 @@ Name | Type | Description  | Notes
 > LogExportClusterInfo GetLogExportInfo(ctx, clusterId).Execute()
 
 Get the Log Export configuration for a cluster
-    
+
 Can be used by the following roles assigned at the organization or cluster scope:
 - ORG_ADMIN
 

--- a/docs/MetricExportApi.md
+++ b/docs/MetricExportApi.md
@@ -18,7 +18,7 @@ Method | HTTP request | Description
 > DeleteMetricExportResponse DeleteCloudWatchMetricExport(ctx, clusterId).Execute()
 
 Delete the CloudWatch Metric Export configuration for a cluster
-    
+
 Can be used by the following roles assigned at the organization or cluster scope:
 - CLUSTER_ADMIN
 - CLUSTER_OPERATOR_WRITER
@@ -90,7 +90,7 @@ Name | Type | Description  | Notes
 > DeleteMetricExportResponse DeleteDatadogMetricExport(ctx, clusterId).Execute()
 
 Delete the Datadog Metric Export configuration for a cluster
-    
+
 Can be used by the following roles assigned at the organization or cluster scope:
 - CLUSTER_ADMIN
 - CLUSTER_OPERATOR_WRITER
@@ -162,7 +162,7 @@ Name | Type | Description  | Notes
 > CloudWatchMetricExportInfo EnableCloudWatchMetricExport(ctx, clusterId).EnableCloudWatchMetricExportRequest(enableCloudWatchMetricExportRequest).Execute()
 
 Create or update the CloudWatch Metric Export configuration for a cluster
-    
+
 Can be used by the following roles assigned at the organization or cluster scope:
 - CLUSTER_ADMIN
 - CLUSTER_OPERATOR_WRITER
@@ -236,7 +236,7 @@ Name | Type | Description  | Notes
 > DatadogMetricExportInfo EnableDatadogMetricExport(ctx, clusterId).EnableDatadogMetricExportRequest(enableDatadogMetricExportRequest).Execute()
 
 Create or update the Datadog Metric Export configuration for a cluster
-    
+
 Can be used by the following roles assigned at the organization or cluster scope:
 - CLUSTER_ADMIN
 - CLUSTER_OPERATOR_WRITER
@@ -310,7 +310,7 @@ Name | Type | Description  | Notes
 > CloudWatchMetricExportInfo GetCloudWatchMetricExportInfo(ctx, clusterId).Execute()
 
 Get the CloudWatch Metric Export configuration for a cluster
-    
+
 Can be used by the following roles assigned at the organization or cluster scope:
 - CLUSTER_ADMIN
 - CLUSTER_OPERATOR_WRITER
@@ -382,7 +382,7 @@ Name | Type | Description  | Notes
 > DatadogMetricExportInfo GetDatadogMetricExportInfo(ctx, clusterId).Execute()
 
 Get the Datadog Metric Export configuration for a cluster
-    
+
 Can be used by the following roles assigned at the organization or cluster scope:
 - CLUSTER_ADMIN
 - CLUSTER_OPERATOR_WRITER

--- a/docs/OrganizationsApi.md
+++ b/docs/OrganizationsApi.md
@@ -13,7 +13,7 @@ Method | HTTP request | Description
 > Organization GetOrganizationInfo(ctx).Execute()
 
 Get information about the caller's organization
-    
+
 Can be used by the following roles assigned at the organization scope:
 - ORG_ADMIN
 - ORG_MEMBER

--- a/docs/PrivateEndpointServicesApi.md
+++ b/docs/PrivateEndpointServicesApi.md
@@ -16,7 +16,7 @@ Method | HTTP request | Description
 > PrivateEndpointServices CreatePrivateEndpointServices(ctx, clusterId).Execute()
 
 Create all PrivateEndpointServices for a cluster
-    
+
 Can be used by the following roles assigned at the organization or cluster scope:
 - CLUSTER_ADMIN
 - CLUSTER_OPERATOR_WRITER
@@ -88,7 +88,7 @@ Name | Type | Description  | Notes
 > AwsEndpointConnections ListAwsEndpointConnections(ctx, clusterId).Execute()
 
 List all AwsEndpointConnections for a cluster
-    
+
 Can be used by the following roles assigned at the organization or cluster scope:
 - CLUSTER_ADMIN
 - CLUSTER_OPERATOR_WRITER
@@ -160,7 +160,7 @@ Name | Type | Description  | Notes
 > PrivateEndpointServices ListPrivateEndpointServices(ctx, clusterId).Execute()
 
 List all PrivateEndpointServices for a cluster
-    
+
 Can be used by the following roles assigned at the organization or cluster scope:
 - CLUSTER_ADMIN
 - CLUSTER_OPERATOR_WRITER
@@ -232,7 +232,7 @@ Name | Type | Description  | Notes
 > AwsEndpointConnection SetAwsEndpointConnectionState(ctx, clusterId, endpointId).SetAwsEndpointConnectionStateRequest(setAwsEndpointConnectionStateRequest).Execute()
 
 Set the AWS Endpoint Connection state
-    
+
 Can be used by the following roles assigned at the organization or cluster scope:
 - CLUSTER_ADMIN
 - CLUSTER_OPERATOR_WRITER

--- a/docs/RoleManagementApi.md
+++ b/docs/RoleManagementApi.md
@@ -18,7 +18,7 @@ Method | HTTP request | Description
 > GetAllRolesForUserResponse AddUserToRole(ctx, userId, resourceType, resourceId, roleName).Execute()
 
 Add the user to the given role
-    
+
 Roles that will be added as a result of this call must follow the CC rules for role assignment:
 https://www.cockroachlabs.com/docs/cockroachcloud/authorization#which-roles-grant-the-ability-to-add-remove-and-manage-members-in-in-a-cockroachdb-cloud-organization
 
@@ -97,7 +97,7 @@ Name | Type | Description  | Notes
 > GetAllRolesForUserResponse GetAllRolesForUser(ctx, userId).Execute()
 
 Get all Role Grants for a user
-    
+
 Can be used by the following roles assigned at the organization scope:
 - ORG_ADMIN
 - CLUSTER_ADMIN
@@ -169,7 +169,7 @@ Name | Type | Description  | Notes
 > GetPersonUsersByEmailResponse GetPersonUsersByEmail(ctx).Email(email).Execute()
 
 Search person users by email address
-    
+
 Can be used by the following roles assigned at the organization scope:
 - ORG_ADMIN
 - CLUSTER_ADMIN
@@ -237,7 +237,7 @@ Name | Type | Description  | Notes
 > ListRoleGrantsResponse ListRoleGrants(ctx).PaginationPage(paginationPage).PaginationLimit(paginationLimit).PaginationAsOfTime(paginationAsOfTime).PaginationSortOrder(paginationSortOrder).Execute()
 
 List all RoleGrants
-    
+
 Can be used by the following roles assigned at the organization scope:
 - ORG_ADMIN
 - CLUSTER_ADMIN
@@ -312,7 +312,7 @@ Name | Type | Description  | Notes
 > GetAllRolesForUserResponse RemoveUserFromRole(ctx, userId, resourceType, resourceId, roleName).Execute()
 
 Remove the user from the given role
-    
+
 Roles that will be removed as a result of this call must follow the CC rules for role assignment:
 https://www.cockroachlabs.com/docs/cockroachcloud/authorization#which-roles-grant-the-ability-to-add-remove-and-manage-members-in-in-a-cockroachdb-cloud-organization
 
@@ -391,7 +391,7 @@ Name | Type | Description  | Notes
 > GetAllRolesForUserResponse SetRolesForUser(ctx, userId).CockroachCloudSetRolesForUserRequest(cockroachCloudSetRolesForUserRequest).Execute()
 
 Make a user's roles exactly those provided
-    
+
 Roles that will be removed or added as a result of this call must follow the CC rules for role assignment:
 https://www.cockroachlabs.com/docs/cockroachcloud/authorization#which-roles-grant-the-ability-to-add-remove-and-manage-members-in-in-a-cockroachdb-cloud-organization
 

--- a/docs/SCIMApi.md
+++ b/docs/SCIMApi.md
@@ -31,7 +31,7 @@ Method | HTTP request | Description
 > ScimGroup CreateGroup(ctx).CreateGroupRequest(createGroupRequest).Execute()
 
 Create a group
-    
+
 Can be used by the following roles assigned at the organization scope:
 - ORG_ADMIN
 
@@ -98,7 +98,7 @@ Name | Type | Description  | Notes
 > ScimUser CreateUser(ctx).CreateUserRequest(createUserRequest).Execute()
 
 Create a user
-    
+
 Can be used by the following roles assigned at the organization scope:
 - ORG_ADMIN
 
@@ -165,7 +165,7 @@ Name | Type | Description  | Notes
 > map[string]interface{} DeleteGroup(ctx, id).Execute()
 
 Delete a group based on ID
-    
+
 Can be used by the following roles assigned at the organization scope:
 - ORG_ADMIN
 
@@ -236,7 +236,7 @@ Name | Type | Description  | Notes
 > map[string]interface{} DeleteUser(ctx, id).Execute()
 
 Delete a user based on ID
-    
+
 Can be used by the following roles assigned at the organization scope:
 - ORG_ADMIN
 
@@ -307,7 +307,7 @@ Name | Type | Description  | Notes
 > ScimGroup GetGroup(ctx, id).Attributes(attributes).ExcludedAttributes(excludedAttributes).Execute()
 
 Get a group based on ID
-    
+
 Can be used by the following roles assigned at the organization scope:
 - ORG_ADMIN
 
@@ -382,7 +382,7 @@ Name | Type | Description  | Notes
 > ScimGroup GetGroup2(ctx, id).GetGroupRequest(getGroupRequest).Execute()
 
 Get a group based on ID
-    
+
 Can be used by the following roles assigned at the organization scope:
 - ORG_ADMIN
 
@@ -455,7 +455,7 @@ Name | Type | Description  | Notes
 > GetGroupsResponse GetGroups(ctx).Attributes(attributes).ExcludedAttributes(excludedAttributes).Execute()
 
 Get groups based on query parameters
-    
+
 Can be used by the following roles assigned at the organization scope:
 - ORG_ADMIN
 
@@ -524,7 +524,7 @@ Name | Type | Description  | Notes
 > GetGroupsResponse GetGroups2(ctx).GetGroupsRequest(getGroupsRequest).Execute()
 
 Get groups based on query parameters
-    
+
 Can be used by the following roles assigned at the organization scope:
 - ORG_ADMIN
 
@@ -591,7 +591,7 @@ Name | Type | Description  | Notes
 > ScimResourceType GetResourceType(ctx, resourceId).Attributes(attributes).ExcludedAttributes(excludedAttributes).Execute()
 
 
-    
+
 This endpoint may be used by any member of the organization.
 
 ### Example
@@ -664,7 +664,7 @@ Name | Type | Description  | Notes
 > GetResourceTypesResponse GetResourceTypes(ctx).Attributes(attributes).ExcludedAttributes(excludedAttributes).Execute()
 
 
-    
+
 This endpoint may be used by any member of the organization.
 
 ### Example
@@ -731,7 +731,7 @@ Name | Type | Description  | Notes
 > ScimSchema GetSchema(ctx, schemaId).Attributes(attributes).ExcludedAttributes(excludedAttributes).Execute()
 
 
-    
+
 This endpoint may be used by any member of the organization.
 
 ### Example
@@ -804,7 +804,7 @@ Name | Type | Description  | Notes
 > GetSchemasResponse GetSchemas(ctx).Attributes(attributes).ExcludedAttributes(excludedAttributes).Execute()
 
 
-    
+
 This endpoint may be used by any member of the organization.
 
 ### Example
@@ -871,7 +871,7 @@ Name | Type | Description  | Notes
 > GetServiceProviderConfigResponse GetServiceProviderConfig(ctx).Execute()
 
 Return our SCIM configuration
-    
+
 This endpoint may be used by any member of the organization.
 
 ### Example
@@ -931,7 +931,7 @@ Other parameters are passed through a pointer to a apiGetServiceProviderConfig s
 > ScimUser GetUser(ctx, id).Attributes(attributes).ExcludedAttributes(excludedAttributes).Execute()
 
 Get a user based on ID
-    
+
 Can be used by the following roles assigned at the organization scope:
 - ORG_ADMIN
 
@@ -1006,7 +1006,7 @@ Name | Type | Description  | Notes
 > ScimUser GetUser2(ctx, id).GetUserRequest(getUserRequest).Execute()
 
 Get a user based on ID
-    
+
 Can be used by the following roles assigned at the organization scope:
 - ORG_ADMIN
 
@@ -1079,7 +1079,7 @@ Name | Type | Description  | Notes
 > GetUsersResponse GetUsers(ctx).Filter(filter).Attributes(attributes).ExcludedAttributes(excludedAttributes).Execute()
 
 Get Users based on query parameters
-    
+
 Can be used by the following roles assigned at the organization scope:
 - ORG_ADMIN
 
@@ -1150,7 +1150,7 @@ Name | Type | Description  | Notes
 > GetUsersResponse GetUsers2(ctx).GetUsersRequest(getUsersRequest).Execute()
 
 Get Users based on query parameters
-    
+
 Can be used by the following roles assigned at the organization scope:
 - ORG_ADMIN
 
@@ -1217,7 +1217,7 @@ Name | Type | Description  | Notes
 > ScimGroup UpdateGroup(ctx, id).UpdateGroupRequest(updateGroupRequest).Execute()
 
 Update a group by supplying all values of the user object
-    
+
 Can be used by the following roles assigned at the organization scope:
 - ORG_ADMIN
 
@@ -1290,7 +1290,7 @@ Name | Type | Description  | Notes
 > ScimUser UpdateUser(ctx, id).UpdateUserRequest(updateUserRequest).Execute()
 
 Update a user by supplying all values of the user object
-    
+
 Can be used by the following roles assigned at the organization scope:
 - ORG_ADMIN
 

--- a/docs/SQLUsersApi.md
+++ b/docs/SQLUsersApi.md
@@ -16,7 +16,7 @@ Method | HTTP request | Description
 > SQLUser CreateSQLUser(ctx, clusterId).CreateSQLUserRequest(createSQLUserRequest).Execute()
 
 Create a new SQL user
-    
+
 Can be used by the following roles assigned at the organization or cluster scope:
 - CLUSTER_ADMIN
 
@@ -89,7 +89,7 @@ Name | Type | Description  | Notes
 > SQLUser DeleteSQLUser(ctx, clusterId, name).Execute()
 
 Delete a SQL user
-    
+
 Can be used by the following roles assigned at the organization or cluster scope:
 - CLUSTER_ADMIN
 
@@ -163,7 +163,7 @@ Name | Type | Description  | Notes
 > ListSQLUsersResponse ListSQLUsers(ctx, clusterId).PaginationPage(paginationPage).PaginationLimit(paginationLimit).PaginationAsOfTime(paginationAsOfTime).PaginationSortOrder(paginationSortOrder).Execute()
 
 List SQL users for a cluster
-    
+
 Can be used by the following roles assigned at the organization or cluster scope:
 - CLUSTER_ADMIN
 - CLUSTER_OPERATOR_WRITER
@@ -245,7 +245,7 @@ Name | Type | Description  | Notes
 > SQLUser UpdateSQLUserPassword(ctx, clusterId, name).UpdateSQLUserPasswordRequest(updateSQLUserPasswordRequest).Execute()
 
 Update a SQL user's password
-    
+
 Can be used by the following roles assigned at the organization or cluster scope:
 - CLUSTER_ADMIN
 

--- a/docs/ServerlessClusterUpdateSpecification.md
+++ b/docs/ServerlessClusterUpdateSpecification.md
@@ -4,6 +4,8 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
+**PrimaryRegion** | Pointer to **string** | Preview: Specify which region should be made the primary region. This is only applicable to multi-region Serverless clusters. This field is required if the regions field contains more than one region. | [optional] 
+**Regions** | Pointer to **[]string** | Region values should match the cloud provider&#39;s zone code. For example, for Oregon, set region_name to \&quot;us-west2\&quot; for GCP and \&quot;us-west-2\&quot; for AWS. If this field is provided, the cluster&#39;s regions will be changed to match this list. Regions cannot currently be removed. | [optional] 
 **SpendLimit** | Pointer to **int32** | spend_limit is the maximum monthly charge for a cluster, in US cents. We recommend using usage_limits instead, since spend_limit will be deprecated in the future. | [optional] 
 **UsageLimits** | Pointer to [**UsageLimits**](UsageLimits.md) |  | [optional] 
 
@@ -17,6 +19,30 @@ NewServerlessClusterUpdateSpecification instantiates a new ServerlessClusterUpda
 This constructor will assign default values to properties that have it defined,
 and makes sure properties required by API are set, but the set of arguments
 will change when the set of required properties is changed.
+
+### GetPrimaryRegion
+
+`func (o *ServerlessClusterUpdateSpecification) GetPrimaryRegion() string`
+
+GetPrimaryRegion returns the PrimaryRegion field if non-nil, zero value otherwise.
+
+### SetPrimaryRegion
+
+`func (o *ServerlessClusterUpdateSpecification) SetPrimaryRegion(v string)`
+
+SetPrimaryRegion sets PrimaryRegion field to given value.
+
+### GetRegions
+
+`func (o *ServerlessClusterUpdateSpecification) GetRegions() []string`
+
+GetRegions returns the Regions field if non-nil, zero value otherwise.
+
+### SetRegions
+
+`func (o *ServerlessClusterUpdateSpecification) SetRegions(v []string)`
+
+SetRegions sets Regions field to given value.
 
 ### GetSpendLimit
 

--- a/internal/openapi-generator/api/openapi-modified.json
+++ b/internal/openapi-generator/api/openapi-modified.json
@@ -11731,6 +11731,17 @@
       "ServerlessClusterUpdateSpecification": {
         "type": "object",
         "properties": {
+          "primary_region": {
+            "description": "Preview: Specify which region should be made the primary region.\nThis is only applicable to multi-region Serverless clusters.\nThis field is required if the regions field contains more than one region.",
+            "type": "string"
+          },
+          "regions": {
+            "description": "Region values should match the cloud provider's zone code.\nFor example, for Oregon, set region_name to \"us-west2\" for\nGCP and \"us-west-2\" for AWS. If this field is provided, the cluster's\nregions will be changed to match this list.\nRegions cannot currently be removed.",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
           "spend_limit": {
             "description": "spend_limit is the maximum monthly charge for a cluster, in US cents. We\nrecommend using usage_limits instead, since spend_limit will be deprecated\nin the future.",
             "type": "integer",

--- a/internal/openapi-generator/api/openapi.yaml
+++ b/internal/openapi-generator/api/openapi.yaml
@@ -9971,6 +9971,22 @@ components:
       type: object
     ServerlessClusterUpdateSpecification:
       properties:
+        primary_region:
+          description: |-
+            Preview: Specify which region should be made the primary region.
+            This is only applicable to multi-region Serverless clusters.
+            This field is required if the regions field contains more than one region.
+          type: string
+        regions:
+          description: |-
+            Region values should match the cloud provider's zone code.
+            For example, for Oregon, set region_name to "us-west2" for
+            GCP and "us-west-2" for AWS. If this field is provided, the cluster's
+            regions will be changed to match this list.
+            Regions cannot currently be removed.
+          items:
+            type: string
+          type: array
         spend_limit:
           description: |-
             spend_limit is the maximum monthly charge for a cluster, in US cents. We

--- a/internal/spec/openapi.json
+++ b/internal/spec/openapi.json
@@ -11731,6 +11731,17 @@
       "ServerlessClusterUpdateSpecification": {
         "type": "object",
         "properties": {
+          "primary_region": {
+            "description": "Preview: Specify which region should be made the primary region.\nThis is only applicable to multi-region Serverless clusters.\nThis field is required if the regions field contains more than one region.",
+            "type": "string"
+          },
+          "regions": {
+            "description": "Region values should match the cloud provider's zone code.\nFor example, for Oregon, set region_name to \"us-west2\" for\nGCP and \"us-west-2\" for AWS. If this field is provided, the cluster's\nregions will be changed to match this list.\nRegions cannot currently be removed.",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
           "spend_limit": {
             "description": "spend_limit is the maximum monthly charge for a cluster, in US cents. We\nrecommend using usage_limits instead, since spend_limit will be deprecated\nin the future.",
             "type": "integer",

--- a/pkg/client/model_serverless_cluster_update_specification.go
+++ b/pkg/client/model_serverless_cluster_update_specification.go
@@ -20,6 +20,10 @@ package client
 
 // ServerlessClusterUpdateSpecification struct for ServerlessClusterUpdateSpecification.
 type ServerlessClusterUpdateSpecification struct {
+	// Preview: Specify which region should be made the primary region. This is only applicable to multi-region Serverless clusters. This field is required if the regions field contains more than one region.
+	PrimaryRegion *string `json:"primary_region,omitempty"`
+	// Region values should match the cloud provider's zone code. For example, for Oregon, set region_name to \"us-west2\" for GCP and \"us-west-2\" for AWS. If this field is provided, the cluster's regions will be changed to match this list. Regions cannot currently be removed.
+	Regions *[]string `json:"regions,omitempty"`
 	// spend_limit is the maximum monthly charge for a cluster, in US cents. We recommend using usage_limits instead, since spend_limit will be deprecated in the future.
 	SpendLimit  *int32       `json:"spend_limit,omitempty"`
 	UsageLimits *UsageLimits `json:"usage_limits,omitempty"`
@@ -32,6 +36,34 @@ type ServerlessClusterUpdateSpecification struct {
 func NewServerlessClusterUpdateSpecification() *ServerlessClusterUpdateSpecification {
 	p := ServerlessClusterUpdateSpecification{}
 	return &p
+}
+
+// GetPrimaryRegion returns the PrimaryRegion field value if set, zero value otherwise.
+func (o *ServerlessClusterUpdateSpecification) GetPrimaryRegion() string {
+	if o == nil || o.PrimaryRegion == nil {
+		var ret string
+		return ret
+	}
+	return *o.PrimaryRegion
+}
+
+// SetPrimaryRegion gets a reference to the given string and assigns it to the PrimaryRegion field.
+func (o *ServerlessClusterUpdateSpecification) SetPrimaryRegion(v string) {
+	o.PrimaryRegion = &v
+}
+
+// GetRegions returns the Regions field value if set, zero value otherwise.
+func (o *ServerlessClusterUpdateSpecification) GetRegions() []string {
+	if o == nil || o.Regions == nil {
+		var ret []string
+		return ret
+	}
+	return *o.Regions
+}
+
+// SetRegions gets a reference to the given []string and assigns it to the Regions field.
+func (o *ServerlessClusterUpdateSpecification) SetRegions(v []string) {
+	o.Regions = &v
 }
 
 // GetSpendLimit returns the SpendLimit field value if set, zero value otherwise.


### PR DESCRIPTION
Because the openapi spec for editing serverless regions isn't in production yet, I manually copied this one from staging before running make. If we'd rather wait for it to be in production that would be okay though.