### PR TITLE
add summary / deprecation to service interface template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+
+BUG FIXES:
+
+* Updated templates to include the deprecation notice in the service interface
+  docs.
+
+## 1.8.0
+
 ## 1.7.0 (September 6, 2023)
 
 NEW FEATURES:

--- a/internal/spec/templates/service.mustache
+++ b/internal/spec/templates/service.mustache
@@ -12,7 +12,13 @@ import (
 )
 
 type Service interface {
-    {{#apiInfo}}{{#apis}}// {{{baseName}}}{{#operations}}{{#operation}}
+    {{#apiInfo}}{{#apis}}
+	//
+	// {{{baseName}}}
+	//
+
+	{{#operations}}{{#operation}}
+		{{#isDeprecated}}// Deprecated: {{summary}}{{/isDeprecated}}{{^isDeprecated}}// {{summary}}{{/isDeprecated}}
         {{nickname}}(ctx _context.Context{{#allParams}}{{#required}}, {{paramName}} {{^isPathParam}}*{{/isPathParam}}{{{dataType}}}{{/required}}{{/allParams}}{{#hasOptionalParams}}, options *{{nickname}}Options{{/hasOptionalParams}}) ({{^returnTypeIsPrimitive}}{{#returnType}}*{{{.}}}, {{/returnType}}{{/returnTypeIsPrimitive}}*_nethttp.Response, error){{/operation}}
 	{{/operations}}{{/apis}}{{/apiInfo}}
 }

--- a/pkg/client/service.go
+++ b/pkg/client/service.go
@@ -29,128 +29,308 @@ import (
 )
 
 type Service interface {
+
+	//
 	// AuditLogs
+	//
+
+	// List audit logs
 	ListAuditLogs(ctx _context.Context, options *ListAuditLogsOptions) (*ListAuditLogsResponse, *_nethttp.Response, error)
+
+	//
 	// Billing
+	//
+
+	// Get a specific invoice for an organization
 	GetInvoice(ctx _context.Context, invoiceId string) (*Invoice, *_nethttp.Response, error)
+	// List invoices for a given organization
 	ListInvoices(ctx _context.Context) (*ListInvoicesResponse, *_nethttp.Response, error)
+
+	//
 	// ClientCACertificates
+	//
+
+	// Delete Client CA Cert for a cluster
 	DeleteClientCACert(ctx _context.Context, clusterId string) (*ClientCACertInfo, *_nethttp.Response, error)
+	// Get Client CA Cert information for a cluster
 	GetClientCACert(ctx _context.Context, clusterId string) (*ClientCACertInfo, *_nethttp.Response, error)
+	// Set Client CA Cert for a cluster
 	SetClientCACert(ctx _context.Context, clusterId string, setClientCACertRequest *SetClientCACertRequest) (*ClientCACertInfo, *_nethttp.Response, error)
+	// Update Client CA Cert for a cluster
 	UpdateClientCACert(ctx _context.Context, clusterId string, updateClientCACertRequest *UpdateClientCACertRequest) (*ClientCACertInfo, *_nethttp.Response, error)
+
+	//
 	// Clusters
+	//
+
+	// Create and initialize a new cluster
 	CreateCluster(ctx _context.Context, createClusterRequest *CreateClusterRequest) (*Cluster, *_nethttp.Response, error)
+	// Delete a cluster and all of its data
 	DeleteCluster(ctx _context.Context, clusterId string) (*Cluster, *_nethttp.Response, error)
+	// Get extended information about a cluster
 	GetCluster(ctx _context.Context, clusterId string) (*Cluster, *_nethttp.Response, error)
+	// Get a formatted generic connection string for a cluster
 	GetConnectionString(ctx _context.Context, clusterId string, options *GetConnectionStringOptions) (*GetConnectionStringResponse, *_nethttp.Response, error)
+	// List the regions available for new clusters and nodes
 	ListAvailableRegions(ctx _context.Context, options *ListAvailableRegionsOptions) (*ListAvailableRegionsResponse, *_nethttp.Response, error)
+	// List nodes for a cluster
 	ListClusterNodes(ctx _context.Context, clusterId string, options *ListClusterNodesOptions) (*ListClusterNodesResponse, *_nethttp.Response, error)
+	// List clusters owned by an organization
 	ListClusters(ctx _context.Context, options *ListClustersOptions) (*ListClustersResponse, *_nethttp.Response, error)
+	// List available major cluster versions
 	ListMajorClusterVersions(ctx _context.Context, options *ListMajorClusterVersionsOptions) (*ListMajorClusterVersionsResponse, *_nethttp.Response, error)
+	// Scale, edit or upgrade a cluster
 	UpdateCluster(ctx _context.Context, clusterId string, updateClusterSpecification *UpdateClusterSpecification) (*Cluster, *_nethttp.Response, error)
+
+	//
 	// CustomerManagedEncryptionKeys
+	//
+
+	// Enable CMEK for a cluster
 	EnableCMEKSpec(ctx _context.Context, clusterId string, cMEKClusterSpecification *CMEKClusterSpecification) (*CMEKClusterInfo, *_nethttp.Response, error)
+	// Get CMEK-related information for a cluster
 	GetCMEKClusterInfo(ctx _context.Context, clusterId string) (*CMEKClusterInfo, *_nethttp.Response, error)
+	// Enable or update the CMEK spec for a cluster
 	UpdateCMEKSpec(ctx _context.Context, clusterId string, cMEKClusterSpecification *CMEKClusterSpecification) (*CMEKClusterInfo, *_nethttp.Response, error)
+	// Update the CMEK-related status for a cluster
 	UpdateCMEKStatus(ctx _context.Context, clusterId string, updateCMEKStatusRequest *UpdateCMEKStatusRequest) (*CMEKClusterInfo, *_nethttp.Response, error)
+
+	//
 	// Databases
+	//
+
+	// Create a new database
 	CreateDatabase(ctx _context.Context, clusterId string, createDatabaseRequest *CreateDatabaseRequest) (*Database, *_nethttp.Response, error)
+	// Delete a database
 	DeleteDatabase(ctx _context.Context, clusterId string, name string) (*Database, *_nethttp.Response, error)
+	// Update a database
 	EditDatabase(ctx _context.Context, clusterId string, name string, updateDatabaseRequest1 *UpdateDatabaseRequest1) (*Database, *_nethttp.Response, error)
+	// Update a database
 	EditDatabase2(ctx _context.Context, clusterId string, updateDatabaseRequest *UpdateDatabaseRequest) (*Database, *_nethttp.Response, error)
+	// List databases for a cluster
 	ListDatabases(ctx _context.Context, clusterId string, options *ListDatabasesOptions) (*ListDatabasesResponse, *_nethttp.Response, error)
+
+	//
 	// EgressRules
+	//
+
+	// Add an egress rule
 	AddEgressRule(ctx _context.Context, clusterId string, addEgressRuleRequest *AddEgressRuleRequest) (*AddEgressRuleResponse, *_nethttp.Response, error)
+	// Delete an existing egress rule
 	DeleteEgressRule(ctx _context.Context, clusterId string, ruleId string, options *DeleteEgressRuleOptions) (*DeleteEgressRuleResponse, *_nethttp.Response, error)
+	// Edit an existing egress rule
 	EditEgressRule(ctx _context.Context, clusterId string, ruleId string, editEgressRuleRequest *EditEgressRuleRequest) (*EditEgressRuleResponse, *_nethttp.Response, error)
+	// Get an existing egress rule
 	GetEgressRule(ctx _context.Context, clusterId string, ruleId string) (*GetEgressRuleResponse, *_nethttp.Response, error)
+	// List all egress rules associated with a cluster
 	ListEgressRules(ctx _context.Context, clusterId string, options *ListEgressRulesOptions) (*ListEgressRulesResponse, *_nethttp.Response, error)
+	// Outbound traffic management
 	SetEgressTrafficPolicy(ctx _context.Context, clusterId string, setEgressTrafficPolicyRequest *SetEgressTrafficPolicyRequest) (*_nethttp.Response, error)
+
+	//
 	// Folders
+	//
+
+	// Create a folder
 	CreateFolder(ctx _context.Context, createFolderRequest *CreateFolderRequest) (*FolderResource, *_nethttp.Response, error)
+	// Delete a folder
 	DeleteFolder(ctx _context.Context, folderId string) (*_nethttp.Response, error)
+	// Get folder info for a folder
 	GetFolder(ctx _context.Context, folderId string) (*FolderResource, *_nethttp.Response, error)
+	// List contents of a folder
 	ListFolderContents(ctx _context.Context, folderId string, options *ListFolderContentsOptions) (*FolderResourceList, *_nethttp.Response, error)
+	// Update a folder
 	UpdateFolder(ctx _context.Context, folderId string, updateFolderSpecification *UpdateFolderSpecification) (*FolderResource, *_nethttp.Response, error)
+
+	//
 	// IPAllowlists
+	//
+
+	// Add a new CIDR address to the IP allowlist
 	AddAllowlistEntry(ctx _context.Context, clusterId string, allowlistEntry *AllowlistEntry) (*AllowlistEntry, *_nethttp.Response, error)
+	// Add a new CIDR address to the IP allowlist
 	AddAllowlistEntry2(ctx _context.Context, clusterId string, entryCidrIp string, entryCidrMask int32, allowlistEntry1 *AllowlistEntry1) (*AllowlistEntry, *_nethttp.Response, error)
+	// Delete an IP allowlist entry
 	DeleteAllowlistEntry(ctx _context.Context, clusterId string, cidrIp string, cidrMask int32) (*AllowlistEntry, *_nethttp.Response, error)
+	// Get the IP allowlist and propagation status for a cluster
 	ListAllowlistEntries(ctx _context.Context, clusterId string, options *ListAllowlistEntriesOptions) (*ListAllowlistEntriesResponse, *_nethttp.Response, error)
+	// Update an IP allowlist entry
 	UpdateAllowlistEntry(ctx _context.Context, clusterId string, entryCidrIp string, entryCidrMask int32, allowlistEntry1 *AllowlistEntry1) (*AllowlistEntry, *_nethttp.Response, error)
+
+	//
 	// LogExport
+	//
+
+	// Delete the Log Export configuration for a cluster
 	DeleteLogExport(ctx _context.Context, clusterId string) (*LogExportClusterInfo, *_nethttp.Response, error)
+	// Create or update the Log Export configuration for a cluster
 	EnableLogExport(ctx _context.Context, clusterId string, enableLogExportRequest *EnableLogExportRequest) (*LogExportClusterInfo, *_nethttp.Response, error)
+	// Get the Log Export configuration for a cluster
 	GetLogExportInfo(ctx _context.Context, clusterId string) (*LogExportClusterInfo, *_nethttp.Response, error)
+
+	//
 	// MaintenanceWindows
+	//
+
+	// Delete the maintenance window for a cluster
 	DeleteMaintenanceWindow(ctx _context.Context, clusterId string) (*MaintenanceWindow, *_nethttp.Response, error)
+	// Get the maintenance window for a cluster
 	GetMaintenanceWindow(ctx _context.Context, clusterId string) (*MaintenanceWindow, *_nethttp.Response, error)
+	// Set the maintenance window for a cluster
 	SetMaintenanceWindow(ctx _context.Context, clusterId string, maintenanceWindow *MaintenanceWindow) (*MaintenanceWindow, *_nethttp.Response, error)
+
+	//
 	// MetricExport
+	//
+
+	// Delete the CloudWatch Metric Export configuration for a cluster
 	DeleteCloudWatchMetricExport(ctx _context.Context, clusterId string) (*DeleteMetricExportResponse, *_nethttp.Response, error)
+	// Delete the Datadog Metric Export configuration for a cluster
 	DeleteDatadogMetricExport(ctx _context.Context, clusterId string) (*DeleteMetricExportResponse, *_nethttp.Response, error)
+	// Delete the Prometheus Metric Export configuration for a cluster
 	DeletePrometheusMetricExport(ctx _context.Context, clusterId string) (*DeleteMetricExportResponse, *_nethttp.Response, error)
+	// Create or update the CloudWatch Metric Export configuration for a cluster
 	EnableCloudWatchMetricExport(ctx _context.Context, clusterId string, enableCloudWatchMetricExportRequest *EnableCloudWatchMetricExportRequest) (*CloudWatchMetricExportInfo, *_nethttp.Response, error)
+	// Create or update the Datadog Metric Export configuration for a cluster
 	EnableDatadogMetricExport(ctx _context.Context, clusterId string, enableDatadogMetricExportRequest *EnableDatadogMetricExportRequest) (*DatadogMetricExportInfo, *_nethttp.Response, error)
+	// Create or update the Prometheus Metric Export configuration for a cluster
 	EnablePrometheusMetricExport(ctx _context.Context, clusterId string, body *map[string]interface{}) (*PrometheusMetricExportInfo, *_nethttp.Response, error)
+	// Get the CloudWatch Metric Export configuration for a cluster
 	GetCloudWatchMetricExportInfo(ctx _context.Context, clusterId string) (*CloudWatchMetricExportInfo, *_nethttp.Response, error)
+	// Get the Datadog Metric Export configuration for a cluster
 	GetDatadogMetricExportInfo(ctx _context.Context, clusterId string) (*DatadogMetricExportInfo, *_nethttp.Response, error)
+	// Get the Prometheus Metric Export configuration for a cluster
 	GetPrometheusMetricExportInfo(ctx _context.Context, clusterId string) (*PrometheusMetricExportInfo, *_nethttp.Response, error)
+
+	//
 	// OpenIDConnectConfiguration
+	//
+
+	// Create an API OIDC configuration
 	CreateApiOidcConfig(ctx _context.Context, createApiOidcConfigRequest *CreateApiOidcConfigRequest) (*ApiOidcConfig, *_nethttp.Response, error)
+	// Delete an API OIDC configuration
 	DeleteApiOidcConfig(ctx _context.Context, id string) (*ApiOidcConfig, *_nethttp.Response, error)
+	// Get an API OIDC configuration
 	GetApiOidcConfig(ctx _context.Context, id string) (*ApiOidcConfig, *_nethttp.Response, error)
+	// List all API OIDC configurations
 	ListApiOidcConfig(ctx _context.Context, options *ListApiOidcConfigOptions) (*ListApiOidcConfigResponse, *_nethttp.Response, error)
+	// Update an API OIDC configuration
 	UpdateApiOidcConfig(ctx _context.Context, id string, apiOidcConfig1 *ApiOidcConfig1) (*ApiOidcConfig, *_nethttp.Response, error)
+
+	//
 	// Organizations
+	//
+
+	// Get information about the caller&#39;s organization
 	GetOrganizationInfo(ctx _context.Context) (*Organization, *_nethttp.Response, error)
+
+	//
 	// PrivateEndpointServices
+	//
+
+	// Add a connection to a cluster&#39;s private endpoint service.
 	AddPrivateEndpointConnection(ctx _context.Context, clusterId string, addPrivateEndpointConnectionRequest *AddPrivateEndpointConnectionRequest) (*PrivateEndpointConnection, *_nethttp.Response, error)
+	// Add a private endpoint trusted owner to a cluster
 	AddPrivateEndpointTrustedOwner(ctx _context.Context, clusterId string, addPrivateEndpointTrustedOwnerRequest *AddPrivateEndpointTrustedOwnerRequest) (*AddPrivateEndpointTrustedOwnerResponse, *_nethttp.Response, error)
+	// Create all PrivateEndpointServices for a cluster
 	CreatePrivateEndpointServices(ctx _context.Context, clusterId string) (*PrivateEndpointServices, *_nethttp.Response, error)
+	// Delete a connection from a cluster&#39;s private endpoint service.
 	DeletePrivateEndpointConnection(ctx _context.Context, clusterId string, endpointId string) (*_nethttp.Response, error)
+	// Get a private endpoint trusted owner entry for a cluster
 	GetPrivateEndpointTrustedOwner(ctx _context.Context, clusterId string, ownerId string) (*GetPrivateEndpointTrustedOwnerResponse, *_nethttp.Response, error)
+	// List all AwsEndpointConnections for a cluster
 	ListAwsEndpointConnections(ctx _context.Context, clusterId string) (*AwsEndpointConnections, *_nethttp.Response, error)
+	// List all connections to a cluster&#39;s private endpoint service.
 	ListPrivateEndpointConnections(ctx _context.Context, clusterId string) (*PrivateEndpointConnections, *_nethttp.Response, error)
+	// List all PrivateEndpointServices for a cluster
 	ListPrivateEndpointServices(ctx _context.Context, clusterId string) (*PrivateEndpointServices, *_nethttp.Response, error)
+	// List all private endpoint trusted owners for a cluster
 	ListPrivateEndpointTrustedOwners(ctx _context.Context, clusterId string) (*ListPrivateEndpointTrustedOwnersResponse, *_nethttp.Response, error)
+	// Remove a private endpoint trusted owner from a cluster
 	RemovePrivateEndpointTrustedOwner(ctx _context.Context, clusterId string, ownerId string) (*RemovePrivateEndpointTrustedOwnerResponse, *_nethttp.Response, error)
+	// Set the AWS Endpoint Connection state
 	SetAwsEndpointConnectionState(ctx _context.Context, clusterId string, endpointId string, setAwsEndpointConnectionStateRequest *SetAwsEndpointConnectionStateRequest) (*AwsEndpointConnection, *_nethttp.Response, error)
+
+	//
 	// RoleManagement
+	//
+
+	// Add the user to the given role
 	AddUserToRole(ctx _context.Context, userId string, resourceType string, resourceId string, roleName string) (*GetAllRolesForUserResponse, *_nethttp.Response, error)
+	// Get all Role Grants for a user
 	GetAllRolesForUser(ctx _context.Context, userId string) (*GetAllRolesForUserResponse, *_nethttp.Response, error)
+	// Search person users by email address
 	GetPersonUsersByEmail(ctx _context.Context, email *string) (*GetPersonUsersByEmailResponse, *_nethttp.Response, error)
+	// List all RoleGrants
 	ListRoleGrants(ctx _context.Context, options *ListRoleGrantsOptions) (*ListRoleGrantsResponse, *_nethttp.Response, error)
+	// Remove the user from the given role
 	RemoveUserFromRole(ctx _context.Context, userId string, resourceType string, resourceId string, roleName string) (*GetAllRolesForUserResponse, *_nethttp.Response, error)
+	// Make a user&#39;s roles exactly those provided
 	SetRolesForUser(ctx _context.Context, userId string, cockroachCloudSetRolesForUserRequest *CockroachCloudSetRolesForUserRequest) (*GetAllRolesForUserResponse, *_nethttp.Response, error)
+
+	//
 	// SCIM
+	//
+
+	// Create a group
 	CreateGroup(ctx _context.Context, createGroupRequest *CreateGroupRequest) (*ScimGroup, *_nethttp.Response, error)
+	// Create a user
 	CreateUser(ctx _context.Context, createUserRequest *CreateUserRequest) (*ScimUser, *_nethttp.Response, error)
+	// Delete a group based on ID
 	DeleteGroup(ctx _context.Context, id string) (*_nethttp.Response, error)
+	// Delete a user based on ID
 	DeleteUser(ctx _context.Context, id string) (*_nethttp.Response, error)
+	// Get a group based on ID
 	GetGroup(ctx _context.Context, id string, options *GetGroupOptions) (*ScimGroup, *_nethttp.Response, error)
+	// Get a group based on ID
 	GetGroup2(ctx _context.Context, id string, getGroupRequest *GetGroupRequest) (*ScimGroup, *_nethttp.Response, error)
+	// Get groups based on query parameters
 	GetGroups(ctx _context.Context, options *GetGroupsOptions) (*GetGroupsResponse, *_nethttp.Response, error)
+	// Get groups based on query parameters
 	GetGroups2(ctx _context.Context, getGroupsRequest *GetGroupsRequest) (*GetGroupsResponse, *_nethttp.Response, error)
+	// Get a SCIM resource type by ID
 	GetResourceType(ctx _context.Context, resourceId string, options *GetResourceTypeOptions) (*ScimResourceType, *_nethttp.Response, error)
+	// List the SCIM resource types
 	GetResourceTypes(ctx _context.Context, options *GetResourceTypesOptions) (*GetResourceTypesResponse, *_nethttp.Response, error)
+	// Get a SCIM schema by ID
 	GetSchema(ctx _context.Context, schemaId string, options *GetSchemaOptions) (*ScimSchema, *_nethttp.Response, error)
+	// List the SCIM schemas
 	GetSchemas(ctx _context.Context, options *GetSchemasOptions) (*GetSchemasResponse, *_nethttp.Response, error)
+	// Return the SCIM Service Provider configuration
 	GetServiceProviderConfig(ctx _context.Context) (*GetServiceProviderConfigResponse, *_nethttp.Response, error)
+	// Get a user based on ID
 	GetUser(ctx _context.Context, id string, options *GetUserOptions) (*ScimUser, *_nethttp.Response, error)
+	// Get a user based on ID
 	GetUser2(ctx _context.Context, id string, getUserRequest *GetUserRequest) (*ScimUser, *_nethttp.Response, error)
+	// Get Users based on query parameters
 	GetUsers(ctx _context.Context, options *GetUsersOptions) (*GetUsersResponse, *_nethttp.Response, error)
+	// Get Users based on query parameters
 	GetUsers2(ctx _context.Context, getUsersRequest *GetUsersRequest) (*GetUsersResponse, *_nethttp.Response, error)
+	// Update a group by supplying all values of the user object
 	UpdateGroup(ctx _context.Context, id string, updateGroupRequest *UpdateGroupRequest) (*ScimGroup, *_nethttp.Response, error)
+	// Update a user by supplying all values of the user object
 	UpdateUser(ctx _context.Context, id string, updateUserRequest *UpdateUserRequest) (*ScimUser, *_nethttp.Response, error)
+
+	//
 	// SQLUsers
+	//
+
+	// Create a new SQL user
 	CreateSQLUser(ctx _context.Context, clusterId string, createSQLUserRequest *CreateSQLUserRequest) (*SQLUser, *_nethttp.Response, error)
+	// Delete a SQL user
 	DeleteSQLUser(ctx _context.Context, clusterId string, name string) (*SQLUser, *_nethttp.Response, error)
+	// List SQL users for a cluster
 	ListSQLUsers(ctx _context.Context, clusterId string, options *ListSQLUsersOptions) (*ListSQLUsersResponse, *_nethttp.Response, error)
+	// Update a SQL user&#39;s password
 	UpdateSQLUserPassword(ctx _context.Context, clusterId string, name string, updateSQLUserPasswordRequest *UpdateSQLUserPasswordRequest) (*SQLUser, *_nethttp.Response, error)
+
+	//
 	// VersionDeferral
+	//
+
+	// Get the version upgrade deferral policy for a cluster.
 	GetClusterVersionDeferral(ctx _context.Context, clusterId string) (*ClusterVersionDeferral, *_nethttp.Response, error)
+	// Set the version upgrade deferral policy for a cluster
 	SetClusterVersionDeferral(ctx _context.Context, clusterId string, clusterVersionDeferral *ClusterVersionDeferral) (*ClusterVersionDeferral, *_nethttp.Response, error)
 }
 


### PR DESCRIPTION
Previously, the deprecation field and docs were only reflected in the generated model types for the sdk and not on the exposed interface for the service.  Projects using the client interact with the interface. This meant that no docs or deprecation notices were being propagated to any IDE loading the client.

This change adds a commented line above each interface member which includes the operation summary.  If the code is marked as deprecated, it prepends this summary with "Deprecated:".

The openapi-generator project includes some functionality for customizing output in the mustache templates but I could find nothing for taking a block of text and converting it to a comment block which would work for godoc. For this reason, I was limited in what I was able to add to godoc for each method. Namely, I could not add any multiline comments.

The documented convention for marking a golang function as deprecated is to prefix any paragraph within the godoc with "Deprecated: " and to use that paragraph for describing why it is deprecated and how to proceed. (https://go.dev/wiki/Deprecated). Despite this, in my tests with VSCode, full support for displaying the deprecation is only reached by having a single line in the doc prefixed with "Deprecated: ".

Given both the limitation with vscode and openapi-generator's current lack of support for creating multi-line comment blocks, we rely on the somewhat non-standard but functioning workaround of prefixing the summary.. In the future, we will hopefully be able to use the full multiline description in the godoc for each method and rely on a Deprecation notice being present.

Here is an example output that we now generate in service.go:

	//
	// SCIM
	//

	// Create a group
	CreateGroup(ctx _context.Context, createGroupRequest *CreateGroupRequest) (*ScimGroup, *_nethttp.Response, error)
	// Get a group by ID
	GetGroup(ctx _context.Context, id string, options *GetGroupOptions) (*ScimGroup, *_nethttp.Response, error)
	// Deprecated: Search a group by ID (Deprecated)
	GetGroup2(ctx _context.Context, id string, getGroupRequest *GetGroupRequest) (*ScimGroup, *_nethttp.Response, error)
	// List groups

<img width="555" alt="Screenshot 2024-03-18 at 1 40 02 PM" src="https://github.com/cockroachdb/cockroach-cloud-sdk-go/assets/6658984/1dad3e10-a145-4c7b-a1d9-2a13f88957d9">
