### PR TITLE
Update changelog for v2.0.1 tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.0.1
+
+BUG FIXES:
+
+* Update module name for v2 rev
+
 ## 2.0.0
 
 BREAKING CHANGES:


### PR DESCRIPTION
Previously the v2.0.0 version was requested before the module was renamed to include /v2.  Go has cached the previous tag so a new one v2.0.1 will be added.