### PR TITLE
Update to latest spec, adds GIB as quantity unit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+
+NEW FEATURES:
+
+* Add GIB to QuantityUnit enum used in billing line items.
+
 ## 2.0.1
 
 BUG FIXES:

--- a/docs/QuantityUnitType.md
+++ b/docs/QuantityUnitType.md
@@ -6,6 +6,8 @@
 
 * `REQUEST_UNITS` (value: `"REQUEST_UNITS"`)
 
+* `GIB` (value: `"GIB"`)
+
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,3 @@
 module github.com/cockroachdb/cockroach-cloud-sdk-go/v2
 
 go 1.17
-
-retract v1.0.1

--- a/internal/openapi-generator/api/openapi-modified.json
+++ b/internal/openapi-generator/api/openapi-modified.json
@@ -15977,7 +15977,8 @@
         "type": "string",
         "enum": [
           "HOURS",
-          "REQUEST_UNITS"
+          "REQUEST_UNITS",
+          "GIB"
         ]
       },
       "Region": {

--- a/internal/openapi-generator/api/openapi.yaml
+++ b/internal/openapi-generator/api/openapi.yaml
@@ -13378,6 +13378,7 @@ components:
       enum:
       - HOURS
       - REQUEST_UNITS
+      - GIB
       type: string
     Region:
       properties:

--- a/internal/spec/openapi.json
+++ b/internal/spec/openapi.json
@@ -15349,7 +15349,7 @@
       },
       "QuantityUnit.Type": {
         "type": "string",
-        "enum": ["HOURS", "REQUEST_UNITS"]
+        "enum": ["HOURS", "REQUEST_UNITS", "GIB"]
       },
       "Region": {
         "type": "object",

--- a/pkg/client/model_quantity_unit_type.go
+++ b/pkg/client/model_quantity_unit_type.go
@@ -29,12 +29,14 @@ type QuantityUnitType string
 const (
 	QUANTITYUNITTYPE_HOURS         QuantityUnitType = "HOURS"
 	QUANTITYUNITTYPE_REQUEST_UNITS QuantityUnitType = "REQUEST_UNITS"
+	QUANTITYUNITTYPE_GIB           QuantityUnitType = "GIB"
 )
 
 // All allowed values of QuantityUnitType enum.
 var AllowedQuantityUnitTypeEnumValues = []QuantityUnitType{
 	"HOURS",
 	"REQUEST_UNITS",
+	"GIB",
 }
 
 // NewQuantityUnitTypeFromValue returns a pointer to a valid QuantityUnitType


### PR DESCRIPTION
I'm updating to the latest spec in prep to branch for readding the cloud 2.0 changes on top of this.