### PR TITLE
client: support JWT auth

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   jq:
-    image: stedolan/jq
+    image: ghcr.io/jqlang/jq:1.7.1
     volumes:
       - ./:/go/src/github.com/cockroachdb/cockroach-cloud-sdk-go
     working_dir: /go/src/github.com/cockroachdb/cockroach-cloud-sdk-go

--- a/internal/spec/templates/client.mustache
+++ b/internal/spec/templates/client.mustache
@@ -290,7 +290,7 @@ func (c *Client) prepareRequest(
 	}
 	
 	// Add header for authentication.
-	localVarRequest.Header.Add("Authorization", "Bearer " + c.cfg.apiKey)
+	localVarRequest.Header.Add("Authorization", "Bearer " + c.cfg.apiToken)
 
 	for header, value := range c.cfg.DefaultHeader {
 		localVarRequest.Header.Add(header, value)

--- a/internal/spec/templates/configuration.mustache
+++ b/internal/spec/templates/configuration.mustache
@@ -30,25 +30,52 @@ UserAgent        string            `json:"userAgent,omitempty"`
 Debug            bool              `json:"debug,omitempty"`
 ServerURL        string
 HTTPClient       *http.Client
-apiKey			 string
+apiToken         string
 {{#withCustomMiddlewareFunction}}
     Middleware       MiddlewareFunction
 {{/withCustomMiddlewareFunction}}
 }
 
+// ConfigurationOption is a function that sets some configuration options.
+type ConfigurationOption func(*Configuration)
+
+// WithVanityName sets the vanity name in the request header.
+func WithVanityName(vanityName string) ConfigurationOption {
+return func(cfg *Configuration) {
+cfg.AddDefaultHeader("Cc-Vanity-Name", vanityName)
+}
+}
+
+// WithUsername sets the username in the request header.
+func WithUsername(username string) ConfigurationOption {
+return func(cfg *Configuration) {
+cfg.AddDefaultHeader("Cc-Username", username)
+}
+}
+
 // NewConfiguration returns a new Configuration object.
-func NewConfiguration(apiKey string) *Configuration {
+// The apiToken is a secret that is used to authenticate with the API.
+// It is either the API Key from a Service Account or a JWT from a JWT Issuer
+// configured for the CockroachDB Cloud Organization.
+// In the case of JWT, the vanity name is required and can be provided using the
+// WithVanityName option.
+func NewConfiguration(apiToken string, opts ...ConfigurationOption) *Configuration {
 cfg := &Configuration{
 DefaultHeader:    make(map[string]string),
 UserAgent:        "{{{httpUserAgent}}}{{^httpUserAgent}}ccloud-sdk-go/{{{packageVersion}}}{{/httpUserAgent}}",
 Debug:            false,
 ServerURL:        DefaultServerURL,
-apiKey:			  apiKey,
+apiToken:         apiToken,
 }
 
 {{#version}}
     cfg.AddDefaultHeader("Cc-Version", ApiVersion)
 {{/version}}
+
+for _, opt := range opts {
+opt(cfg)
+}
+
 return cfg
 }
 

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -307,7 +307,7 @@ func (c *Client) prepareRequest(
 	}
 
 	// Add header for authentication.
-	localVarRequest.Header.Add("Authorization", "Bearer "+c.cfg.apiKey)
+	localVarRequest.Header.Add("Authorization", "Bearer "+c.cfg.apiToken)
 
 	for header, value := range c.cfg.DefaultHeader {
 		localVarRequest.Header.Add(header, value)

--- a/pkg/client/configuration.go
+++ b/pkg/client/configuration.go
@@ -35,20 +35,47 @@ type Configuration struct {
 	Debug         bool              `json:"debug,omitempty"`
 	ServerURL     string
 	HTTPClient    *http.Client
-	apiKey        string
+	apiToken      string
+}
+
+// ConfigurationOption is a function that sets some configuration options.
+type ConfigurationOption func(*Configuration)
+
+// WithVanityName sets the vanity name in the request header.
+func WithVanityName(vanityName string) ConfigurationOption {
+	return func(cfg *Configuration) {
+		cfg.AddDefaultHeader("Cc-Vanity-Name", vanityName)
+	}
+}
+
+// WithUsername sets the username in the request header.
+func WithUsername(username string) ConfigurationOption {
+	return func(cfg *Configuration) {
+		cfg.AddDefaultHeader("Cc-Username", username)
+	}
 }
 
 // NewConfiguration returns a new Configuration object.
-func NewConfiguration(apiKey string) *Configuration {
+// The apiToken is a secret that is used to authenticate with the API.
+// It is either the API Key from a Service Account or a JWT from a JWT Issuer
+// configured for the CockroachDB Cloud Organization.
+// In the case of JWT, the vanity name is required and can be provided using the
+// WithVanityName option.
+func NewConfiguration(apiToken string, opts ...ConfigurationOption) *Configuration {
 	cfg := &Configuration{
 		DefaultHeader: make(map[string]string),
 		UserAgent:     "ccloud-sdk-go/4.1.0",
 		Debug:         false,
 		ServerURL:     DefaultServerURL,
-		apiKey:        apiKey,
+		apiToken:      apiToken,
 	}
 
 	cfg.AddDefaultHeader("Cc-Version", ApiVersion)
+
+	for _, opt := range opts {
+		opt(cfg)
+	}
+
 	return cfg
 }
 


### PR DESCRIPTION
This change enables the SDK to access CC APIs via JWT authentication.
This will be used by the Terraform Provider, as some of our customers
have requested for using JWT for provisioning resources through Terraform,
instead of API Keys.

This change also updates the deprecated jq image.