### PR TITLE
[CNSL-1939] Add changelog validation to PR checks

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,14 @@
+name: Changelog Check
+
+on:
+  pull_request:
+    branches:
+      - main
+      - 'pending-deploy-*'
+
+jobs:
+  changelog:
+    uses: cockroachdb/actions/.github/workflows/pr-changelog-check.yml@v0
+    with:
+      base-ref: ${{ github.event.pull_request.base.ref }}
+      pr-number: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
Calls the reusable workflow from cockroachdb/actions to validate CHANGELOG.md format on PRs against main and pending-deploy-* branches. The workflow fails if the changelog is invalid and posts a comment indicating whether breaking changes are detected (entries prefixed with "Breaking Change:").

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>