### PR TITLE
[CNSL-1941] Add release workflow and CLAUDE.md

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,37 @@
+name: Release SDK
+
+on:
+  push:
+    branches: [main]
+
+# contents:write is required for autotag-from-changelog to push tags.
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: cockroachdb/actions/autotag-from-changelog@v0
+        id: autotag
+
+      # Dispatches an sdk-release event to ccloud-private. Requires a
+      # CCLOUD_PRIVATE_DISPATCH_PAT secret — a fine-grained PAT with
+      # contents:write on cockroachdb/ccloud-private, since GITHUB_TOKEN
+      # cannot trigger workflows in other repositories.
+      - name: Dispatch to ccloud-private
+        if: steps.autotag.outputs.tag-created == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.CCLOUD_PRIVATE_DISPATCH_PAT }}
+        run: |
+          if [ -z "$GH_TOKEN" ]; then
+            echo "::warning::CCLOUD_PRIVATE_DISPATCH_PAT secret is not set. Skipping dispatch to ccloud-private for ${{ steps.autotag.outputs.tag }}."
+            exit 0
+          fi
+          gh api repos/cockroachdb/ccloud-private/dispatches \
+            -f event_type=sdk-release \
+            -f "client_payload[version]=${{ steps.autotag.outputs.tag }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Added release workflow that auto-tags from CHANGELOG and dispatches
+  sdk-release events to ccloud-private. Requires a `CCLOUD_PRIVATE_DISPATCH_PAT`
+  repository secret (fine-grained PAT with contents:write on
+  cockroachdb/ccloud-private) and a corresponding `repository_dispatch`
+  workflow in ccloud-private to handle the `sdk-release` event
+
 ## [6.10.0] - 2025-11-19
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+# CLAUDE.md
+
+## GitHub Actions
+
+- When writing or modifying GitHub Actions workflows, always look up the latest major version of each action before using it. Do not assume you know the current version.


### PR DESCRIPTION
Add a GitHub Actions workflow that runs autotag-from-changelog on pushes to main and dispatches an sdk-release event to ccloud-private when a new tag is created.

The dispatch step requires a DISPATCH_TOKEN repository secret with repo scope on cockroachdb/ccloud-private, and a repository_dispatch workflow in ccloud-private listening for the sdk-release event type. Neither exists yet.

Note for reviewers:

this does not tackle the branch management for the planned pending releases branches.  I was thinking we could do that in a separate PR.