### PR TITLE
[CNSL-1935] Add automated release PR workflow

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -1,0 +1,33 @@
+name: Create Release PR
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: write  # Push to fork and create branch
+  pull-requests: write  # Create release PR
+
+jobs:
+  create-release-pr:
+    # Run on merged PRs with automation/pending-deploy- prefix, or manual workflow_dispatch
+    if: github.event_name == 'workflow_dispatch' || (github.event.pull_request.merged && startsWith(github.event.pull_request.head.ref, 'automation/pending-deploy-'))
+    uses: cockroachdb/actions/.github/workflows/create-release-pr.yml@v0
+    with:
+      fork_owner: crl-gh-actions-pr-bot
+      fork_repo: cockroach-cloud-sdk-go
+      build_script: scripts/update_version.sh
+      files_to_commit: |
+        go.mod
+        main.go
+        internal/spec/config.yaml
+        README.md
+        docs/README.md
+        pkg/client/configuration.go
+      allow_fork_force_sync: true
+    secrets:
+      fork_push_token: ${{ secrets.FORK_PUSH_TOKEN }}
+      pr_create_token: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Automated release workflow that creates release PRs when `automation/pending-deploy-*`
+  branches are merged to main, updating the version number in all relevant files
+
 ## [7.1.0] - 2026-04-14
 
 ### Added

--- a/scripts/lib/actions-helpers.sh
+++ b/scripts/lib/actions-helpers.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Logging functions for GitHub Actions workflows
+
+# Output an informational message to stdout
+log_info() {
+  local message="$1"
+  echo "$message"
+}
+
+# Output an error message using GitHub Actions workflow command format
+# https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-error-message
+log_error() {
+  local message="$1"
+  echo "::error::$message" >&2
+}
+
+# Output a warning message using GitHub Actions workflow command format
+log_warning() {
+  local message="$1"
+  echo "::warning::$message" >&2
+}
+
+# Output a notice message using GitHub Actions workflow command format
+log_notice() {
+  local message="$1"
+  echo "::notice::$message"
+}
+
+# Write a single-line output: set_output key value
+set_output() {
+  echo "$1=$2" >> "${GITHUB_OUTPUT:-/dev/null}"
+}

--- a/scripts/lib/validation.sh
+++ b/scripts/lib/validation.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Validation helper functions
+
+# Check if required commands are available in PATH
+# Usage: check_required_commands "cmd1" "cmd2" "cmd3"
+check_required_commands() {
+  local missing_commands=()
+
+  for cmd in "$@"; do
+    if ! command -v "$cmd" >/dev/null 2>&1; then
+      missing_commands+=("$cmd")
+    fi
+  done
+
+  if [[ ${#missing_commands[@]} -gt 0 ]]; then
+    log_error "Required command(s) not found in PATH: ${missing_commands[*]}"
+    return 1
+  fi
+
+  return 0
+}

--- a/scripts/update_version.sh
+++ b/scripts/update_version.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+set -e
+
+# This script is called by the reusable workflow after CHANGELOG.md has been updated.
+# The VERSION environment variable is set by the reusable workflow.
+# This script should only update version numbers in files other than CHANGELOG.md.
+
+# Get the script directory
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Source helper functions
+source "$SCRIPT_DIR/lib/actions-helpers.sh"
+source "$SCRIPT_DIR/lib/validation.sh"
+
+# Check required commands are available
+check_required_commands cut sed make
+
+# Check if VERSION environment variable is set
+if [ -z "$VERSION" ]; then
+    log_error "VERSION environment variable is required"
+    log_error "This script is intended to be called by the create-release-pr workflow"
+    exit 1
+fi
+
+log_info "Updating version to $VERSION in config and documentation files..."
+
+# Extract major version from VERSION (e.g., 7.0.0 -> 7)
+MAJOR_VERSION=$(echo "$VERSION" | cut --delimiter=. --fields=1)
+
+# Update go.mod module path to match major version
+log_info "Updating go.mod..."
+sed --regexp-extended "s|(github.com/cockroachdb/cockroach-cloud-sdk-go)/v[0-9]+|\1/v${MAJOR_VERSION}|" go.mod > go.mod.tmp && mv go.mod.tmp go.mod
+
+# Update main.go import path to match major version
+log_info "Updating main.go..."
+sed --regexp-extended "s|(github.com/cockroachdb/cockroach-cloud-sdk-go)/v[0-9]+|\1/v${MAJOR_VERSION}|" main.go > main.go.tmp && mv main.go.tmp main.go
+
+# Update internal/spec/config.yaml
+log_info "Updating internal/spec/config.yaml..."
+sed "s/^packageVersion:.*/packageVersion: $VERSION/" internal/spec/config.yaml > internal/spec/config.yaml.tmp && mv internal/spec/config.yaml.tmp internal/spec/config.yaml
+
+# Generate OpenAPI client to update README files
+log_info "Generating OpenAPI client..."
+# Note: sudo is required because docker containers run as root by default,
+# creating files owned by root. We then chown them back to the current user.
+sudo make generate-openapi-client
+sudo chown --recursive "$(id --user):$(id --group)" internal/openapi-generator/ pkg/client/ docs/ README.md
+
+log_info "Version updated to $VERSION"
+
+# Validate the updated code
+log_info "Running validation..."
+make validate


### PR DESCRIPTION
Added GitHub Actions workflow that automatically creates release PRs when automation/pending-deploy-* branches are merged to main. The workflow updates go.mod and main.go for major version changes, updates config.yaml with the new version, and regenerates the OpenAPI client to automatically update all generated files (README.md, docs/README.md, pkg/client/configuration.go, and other generated code).

Example PR: https://github.com/cockroachlabs/cockroach-cloud-sdk-go-automation-testing/pull/185