### PR TITLE
Fix changelog workflow to support fork PRs

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,7 +1,7 @@
 name: Changelog Check
 
 on:
-  pull_request:
+  pull_request_target:
     branches:
       - main
       - 'pending-deploy-*'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Added changelog validation workflow for pull requests
+
 ## [6.10.0] - 2025-11-19
 
 ### Added


### PR DESCRIPTION
## Summary
- Changes `pull_request` to `pull_request_target` in the changelog workflow

## Problem
The changelog workflow fails with 403 errors when PRs are opened from forks because the `pull_request` trigger has read-only permissions for fork PRs, preventing the workflow from posting comments.

## Solution
Use `pull_request_target` which runs with the base repository's permissions, allowing the workflow to post comments on fork PRs.

## Security
This is safe because:
- The workflow only reads changelog files and posts comments
- The workflow code runs from the base branch (main), not from the fork
- No code from the PR is executed

## Test plan
- [x] Verify workflow runs on same-repo PRs
- [ ] Merge to main and verify fork PRs can receive changelog comments