### PR TITLE
Update changelog workflow trigger conditions

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -2,9 +2,8 @@ name: Changelog Check
 
 on:
   pull_request:
-    branches:
-      - main
-      - 'pending-deploy-*'
+    paths:
+      - 'CHANGELOG.md'
 
 jobs:
   changelog:


### PR DESCRIPTION
Runs on all PRs regardless of target branch, but only triggers when the CHANGELOG.md file has been changed in the PR.

Co-Authored-By: roachdev-claude <roachdev-claude-bot@cockroachlabs.com>