### PR TITLE
[CC-34727] Update latest spec to 7.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added `S3VpcEndpointId` field to `Region` model. This is the ID of the AWS S3
+  VPC gateway endpoint associated with a cluster region, used to configure S3
+  bucket policies. Only populated for Advanced clusters on AWS.
+
 ## [7.0.0] - 2026-04-08
 
 ### Added

--- a/docs/Region.md
+++ b/docs/Region.md
@@ -9,6 +9,7 @@ Name | Type | Description | Notes
 **NodeCount** | **int32** | node_count will be 0 for Serverless clusters. | 
 **Primary** | Pointer to **bool** | primary is true only for the primary region in a Multi Region Serverless cluster. | [optional] 
 **PrivateEndpointDns** | **string** | private_endpoint_dns is the DNS name of the cluster which is used to connect to the cluster with GCP Private Service Connect. | 
+**S3VpcEndpointId** | Pointer to **string** | Preview: s3_vpc_endpoint_id is the ID of the AWS S3 VPC gateway endpoint associated with this cluster region. This can be used to configure S3 bucket policies that restrict access to traffic from this VPC endpoint. Only populated for Advanced clusters on AWS. | [optional] 
 **SqlDns** | **string** | sql_dns is the DNS name of SQL interface of the cluster. It is used to connect to the cluster with IP allowlisting. | 
 **UiDns** | **string** | ui_dns is the DNS name used when connecting to the DB Console for the cluster. | 
 
@@ -90,6 +91,18 @@ GetPrivateEndpointDns returns the PrivateEndpointDns field if non-nil, zero valu
 `func (o *Region) SetPrivateEndpointDns(v string)`
 
 SetPrivateEndpointDns sets PrivateEndpointDns field to given value.
+
+### GetS3VpcEndpointId
+
+`func (o *Region) GetS3VpcEndpointId() string`
+
+GetS3VpcEndpointId returns the S3VpcEndpointId field if non-nil, zero value otherwise.
+
+### SetS3VpcEndpointId
+
+`func (o *Region) SetS3VpcEndpointId(v string)`
+
+SetS3VpcEndpointId sets S3VpcEndpointId field to given value.
 
 ### GetSqlDns
 

--- a/internal/openapi-generator/api/openapi-modified.json
+++ b/internal/openapi-generator/api/openapi-modified.json
@@ -19093,6 +19093,10 @@
             "description": "private_endpoint_dns is the DNS name of the cluster which is used to\nconnect to the cluster with GCP Private Service Connect.",
             "type": "string"
           },
+          "s3_vpc_endpoint_id": {
+            "description": "Preview: s3_vpc_endpoint_id is the ID of the AWS S3 VPC gateway endpoint\nassociated with this cluster region. This can be used to configure\nS3 bucket policies that restrict access to traffic from this\nVPC endpoint. Only populated for Advanced clusters on AWS.",
+            "type": "string"
+          },
           "sql_dns": {
             "description": "sql_dns is the DNS name of SQL interface of the cluster. It is used to connect to the cluster with IP allowlisting.",
             "type": "string"
@@ -20238,6 +20242,9 @@
     },
     {
       "name": "Egress Private Endpoints"
+    },
+    {
+      "name": "Multifactor Authentication"
     }
   ],
   "externalDocs": {

--- a/internal/openapi-generator/api/openapi.yaml
+++ b/internal/openapi-generator/api/openapi.yaml
@@ -46,6 +46,7 @@ tags:
 - name: Plan Migrations
 - name: Backup/Restore
 - name: Egress Private Endpoints
+- name: Multifactor Authentication
 paths:
   /api/scim/v2/Groups:
     get:
@@ -16056,6 +16057,13 @@ components:
           description: |-
             private_endpoint_dns is the DNS name of the cluster which is used to
             connect to the cluster with GCP Private Service Connect.
+          type: string
+        s3_vpc_endpoint_id:
+          description: |-
+            Preview: s3_vpc_endpoint_id is the ID of the AWS S3 VPC gateway endpoint
+            associated with this cluster region. This can be used to configure
+            S3 bucket policies that restrict access to traffic from this
+            VPC endpoint. Only populated for Advanced clusters on AWS.
           type: string
         sql_dns:
           description: sql_dns is the DNS name of SQL interface of the cluster. It

--- a/internal/spec/openapi.json
+++ b/internal/spec/openapi.json
@@ -18337,6 +18337,10 @@
             "description": "private_endpoint_dns is the DNS name of the cluster which is used to\nconnect to the cluster with GCP Private Service Connect.",
             "type": "string"
           },
+          "s3_vpc_endpoint_id": {
+            "description": "Preview: s3_vpc_endpoint_id is the ID of the AWS S3 VPC gateway endpoint\nassociated with this cluster region. This can be used to configure\nS3 bucket policies that restrict access to traffic from this\nVPC endpoint. Only populated for Advanced clusters on AWS.",
+            "type": "string"
+          },
           "sql_dns": {
             "description": "sql_dns is the DNS name of SQL interface of the cluster. It is used to connect to the cluster with IP allowlisting.",
             "type": "string"
@@ -19408,6 +19412,9 @@
     },
     {
       "name": "Egress Private Endpoints"
+    },
+    {
+      "name": "Multifactor Authentication"
     }
   ],
   "externalDocs": {

--- a/pkg/client/model_region.go
+++ b/pkg/client/model_region.go
@@ -29,6 +29,8 @@ type Region struct {
 	Primary *bool `json:"primary,omitempty"`
 	// private_endpoint_dns is the DNS name of the cluster which is used to connect to the cluster with GCP Private Service Connect.
 	PrivateEndpointDns string `json:"private_endpoint_dns"`
+	// Preview: s3_vpc_endpoint_id is the ID of the AWS S3 VPC gateway endpoint associated with this cluster region. This can be used to configure S3 bucket policies that restrict access to traffic from this VPC endpoint. Only populated for Advanced clusters on AWS.
+	S3VpcEndpointId *string `json:"s3_vpc_endpoint_id,omitempty"`
 	// sql_dns is the DNS name of SQL interface of the cluster. It is used to connect to the cluster with IP allowlisting.
 	SqlDns string `json:"sql_dns"`
 	// ui_dns is the DNS name used when connecting to the DB Console for the cluster.
@@ -130,6 +132,20 @@ func (o *Region) GetPrivateEndpointDns() string {
 // SetPrivateEndpointDns sets field value.
 func (o *Region) SetPrivateEndpointDns(v string) {
 	o.PrivateEndpointDns = v
+}
+
+// GetS3VpcEndpointId returns the S3VpcEndpointId field value if set, zero value otherwise.
+func (o *Region) GetS3VpcEndpointId() string {
+	if o == nil || o.S3VpcEndpointId == nil {
+		var ret string
+		return ret
+	}
+	return *o.S3VpcEndpointId
+}
+
+// SetS3VpcEndpointId gets a reference to the given string and assigns it to the S3VpcEndpointId field.
+func (o *Region) SetS3VpcEndpointId(v string) {
+	o.S3VpcEndpointId = &v
 }
 
 // GetSqlDns returns the SqlDns field value.


### PR DESCRIPTION
NEW FEATURES:

* Added `S3VpcEndpointId` field to `Region` model for configuring S3 bucket policies on AWS Advanced clusters (CC-34727).
