### PR TITLE
[CC-34727] Finalize CHANGELOG for v7.1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [7.1.0] - 2026-04-14
+
 ### Added
 
 - Added `S3VpcEndpointId` field to `Region` model. This is the ID of the AWS S3


### PR DESCRIPTION
Finalize CHANGELOG for v7.1.0 release. This tags the spec update from #106 which added S3VpcEndpointId to the Region model.

Auto merging without approval because #106 was approved already. This is just a changelog bump.
