### PR TITLE
[CNSL-1930] Add automated OpenAPI spec sync workflow

### DIFF
--- a/.claude/skills/generate-sync-metadata.md
+++ b/.claude/skills/generate-sync-metadata.md
@@ -1,0 +1,70 @@
+# Generate Sync Metadata
+
+This skill is ONLY for the automated OpenAPI sync workflow (scripts/openapi-sync.sh).
+Do not use this skill for manual changelog updates or other changelog work.
+
+Analyze the OpenAPI spec sync changes, update CHANGELOG.md, and generate structured metadata (commit title, commit body, PR title, PR description) for the sync.
+
+## CRITICAL: Source of Truth
+
+**The git diff output is your ONLY source of truth.**
+- Document ONLY what appears in the diff - nothing more, nothing less
+- If something is not in the diff, do NOT document it
+- All changelog entries, commit messages, and PR descriptions must be based ONLY on what you see in the diff
+
+## Instructions
+
+**Step 1: View the changes**
+- Run `printenv BASE_BRANCH` and save the exact output value
+- Run `git diff origin/<BASE_BRANCH_VALUE>` where you substitute `<BASE_BRANCH_VALUE>` with the EXACT value from the printenv command
+  - Example: if printenv output "automation/pending-deploy-20260514-043826", run `git diff origin/automation/pending-deploy-20260514-043826`
+  - Example: if printenv output "main", run `git diff origin/main`
+- **DO NOT** run `git diff main` or `git diff origin/main` IF BASE_BRANCH is NOT `main`
+- **DO NOT** run `git log`, `git show`, or any other git command
+
+**Step 2: Update CHANGELOG.md**
+- Follow the changelog conventions documented in CLAUDE.md
+- IMPORTANT: Only modify CHANGELOG.md. Do not modify any other files including generated code, spec files, or configuration files
+
+**Step 3: Generate commit and PR metadata**
+- Follow the guidelines in the "Output Format" section below
+
+## Output Format
+
+End your response with these exact markers and formatting:
+
+```
+---COMMIT_TITLE---
+<one line, max 72 characters>
+---COMMIT_BODY---
+<multi-line, wrap at 72 characters>
+---PR_TITLE---
+<one line, max 72 characters>
+---PR_DESCRIPTION---
+<multi-line, no wrap limit>
+```
+
+Do not add any text after the PR description section.
+
+## Writing Guidelines
+
+**For Commit Body:**
+- Describe the actual SDK/API changes from a user perspective
+- Focus on WHAT changed in the API/SDK, not the process of updating files
+- DO NOT include file lists - focus on user-facing API/SDK changes
+- Provide a high-level summary (e.g., what new operations are available, what fields were added/modified)
+- Group related changes together (e.g., "Added JWT issuer management operations including create, get, list, update, and delete")
+- For breaking changes, clearly call out what changed and why it might break existing code
+
+**For PR Description:**
+- Start with a reader-friendly summary (2-3 sentences)
+- Describe the actual SDK/API changes from a user perspective, similar to the commit body
+- DO NOT include file lists - focus on user-facing API/SDK changes
+- Can be more detailed than commit body - include context that helps reviewers understand the changes
+
+**For Commit Titles and PR Titles:**
+- Use imperative mood (e.g., "Add", "Update", "Fix", not "Added", "Updated", "Fixed")
+- DO NOT write titles like "Update CHANGELOG.md" - the changelog update is just a side effect, not the main change
+- Titles must be under 72 characters (strict limit)
+- If changes are focused on one specific area, describe that clearly (e.g., "Add MFA audit log actions", "Update invoice field descriptions")
+- For multiple unrelated changes: review your title against all affected endpoints and fields. If your title doesn't cover everything or exceeds 72 characters, use the generic title "Sync OpenAPI spec from managed-service" and describe the changes in the commit body instead.

--- a/.github/workflows/openapi-sync.yml
+++ b/.github/workflows/openapi-sync.yml
@@ -1,0 +1,97 @@
+name: Sync OpenAPI Spec from Managed Service
+
+on:
+  workflow_dispatch:
+    inputs:
+      event_type:
+        description: 'Event type (openapi-spec-changed or openapi-spec-merged)'
+        required: true
+        type: choice
+        options:
+          - openapi-spec-changed
+          - openapi-spec-merged
+      pr_url:
+        description: 'Managed-service PR URL'
+        required: true
+        type: string
+      sha:
+        description: 'Managed-service commit SHA (required for merged events)'
+        required: false
+        type: string
+
+permissions:
+  contents: write       # Push commits to fork branch
+  pull-requests: write  # Create/update pull requests in upstream repo
+  id-token: write       # Authenticate to Google Cloud for Vertex AI
+
+jobs:
+  openapi-sync:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_REPOSITORY: ${{ github.repository }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Validate branch
+        run: |
+          source scripts/lib/actions-helpers.sh
+          if [[ "${{ github.ref }}" != "refs/heads/main" ]]; then
+            log_error "This workflow can only be triggered from the main branch (current ref: ${{ github.ref }})"
+            exit 1
+          fi
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod  # Required by make generate-openapi-client and make validate
+
+      - name: Authenticate to Google Cloud (Vertex AI)
+        uses: google-github-actions/auth@v3
+        with:
+          project_id: vertex-model-runners
+          service_account: vertex-ai-user@vertex-model-runners.iam.gserviceaccount.com
+          workload_identity_provider: projects/108106229451/locations/global/workloadIdentityPools/vertex-ai-user/providers/vertex-ai-user
+
+      - name: Generate updated client from OpenAPI spec
+        id: sync
+        env:
+          EVENT_TYPE: ${{ github.event.inputs.event_type }}
+          MANAGED_SERVICE_PR_URL: ${{ github.event.inputs.pr_url }}
+          MANAGED_SERVICE_SHA: ${{ github.event.inputs.sha }}
+          MANAGED_SERVICE_TOKEN: ${{ secrets.MANAGED_SERVICE_TOKEN }}
+          FORK_OWNER: crl-gh-actions-pr-bot
+          FORK_PUSH_TOKEN: ${{ secrets.FORK_PUSH_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
+        run: scripts/openapi-sync-generate.sh
+
+      - name: Update changelog with Claude
+        id: changelog
+        if: steps.sync.outputs.has_changes == 'true'
+        env:
+          BASE_BRANCH: ${{ steps.sync.outputs.base_branch }}
+          HAS_CHANGES: ${{ steps.sync.outputs.has_changes }}
+        run: scripts/openapi-sync-update-changelog.sh
+
+      - name: Publish changes (commit and create PR)
+        if: steps.sync.outputs.has_changes == 'true' || github.event.inputs.event_type == 'openapi-spec-merged'
+        env:
+          EVENT_TYPE: ${{ github.event.inputs.event_type }}
+          MANAGED_SERVICE_PR_URL: ${{ github.event.inputs.pr_url }}
+          MANAGED_SERVICE_SHA: ${{ github.event.inputs.sha }}
+          FORK_OWNER: crl-gh-actions-pr-bot
+          FORK_PUSH_TOKEN: ${{ secrets.FORK_PUSH_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
+          BASE_BRANCH: ${{ steps.sync.outputs.base_branch }}
+          HAS_CHANGES: ${{ steps.sync.outputs.has_changes }}
+          EXISTING_SDK_PR: ${{ steps.sync.outputs.existing_sdk_pr }}
+          HEAD_BRANCH: ${{ steps.sync.outputs.head_branch }}
+          SDK_PR_NUMBER: ${{ steps.sync.outputs.sdk_pr_number }}
+          COMMIT_TITLE: ${{ steps.changelog.outputs.commit_title }}
+          COMMIT_BODY: ${{ steps.changelog.outputs.commit_body }}
+          PR_TITLE: ${{ steps.changelog.outputs.pr_title }}
+          PR_DESCRIPTION: ${{ steps.changelog.outputs.pr_description }}
+        run: scripts/openapi-sync-publish.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added automated workflow for OpenAPI spec synchronization from managed-service.
+  Supports both `openapi-spec-changed` (creates/updates PRs) and `openapi-spec-merged`
+  (updates PRs with exact merged commit) event types.
 - Automated pending deploy branch management with two GitHub Actions workflows:
   - `pending-deploy-pr.yml`: Creates PRs from pending deploy branches to main (triggered via
     workflow_dispatch) and triggers a pending deploy check

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,3 +3,38 @@
 ## GitHub Actions
 
 - When writing or modifying GitHub Actions workflows, always look up the latest major version of each action before using it. Do not assume you know the current version.
+
+## Changelog
+
+Follow Keep a Changelog conventions when updating CHANGELOG.md.
+
+**Unreleased Section Structure:**
+- The `## [Unreleased]` section starts with the `## [Unreleased]` header and ends when the next `##` level header appears (typically a version like `## [x.y.z]`)
+- It contains subsections: `### Added`, `### Changed`, `### Deprecated`, `### Removed`, `### Fixed`, `### Security`
+- Subsections must appear in this exact order (top to bottom): Added, Changed, Deprecated, Removed, Fixed, Security
+- There should be only ONE of each subsection type within `## [Unreleased]`
+
+**Adding Entries:**
+- Add all new entries under the `## [Unreleased]` section
+- Choose the appropriate subsection based on the change type:
+  - Added: new features
+  - Changed: changes in existing functionality
+  - Deprecated: soon-to-be removed features
+  - Removed: now removed features
+  - Fixed: bug fixes
+  - Security: vulnerabilities
+- If the subsection already exists: add your entry at the top of that subsection's list - DO NOT create a duplicate subsection header
+- If the subsection doesn't exist: create it within the `## [Unreleased]` section, positioned according to the order above (Added, Changed, Deprecated, Removed, Fixed, Security)
+
+**How to Write Changelog Entries:**
+- Be brief. One sentence per entry.
+- Write from the user's perspective. Describe what they can now do, not what code changed.
+- Start each entry with a verb (e.g. Add, Update, Fix, Remove).
+- Prefix breaking changes with "Breaking Change: ".
+- Group related changes into one entry when they form a single feature (e.g. "Add support for folder management operations").
+- Don't list individual fields, models, or implementation details unless they're the primary change.
+- For OpenAPI spec syncs: mention the new operations and capabilities, not the sync process itself.
+
+**Examples:**
+- Good: `Add support for JWT issuer management operations (CreateJwtIssuer, GetJwtIssuer, ListJwtIssuers, UpdateJwtIssuer, DeleteJwtIssuer).`
+- Bad: `Sync OpenAPI spec from managed-service PR #1234 and add JwtIssuer CRUD operations with Audience, IssuerUrl, JwksUri, and ClaimMap fields.`

--- a/Makefile
+++ b/Makefile
@@ -6,9 +6,9 @@ TOOLPATH := $(abspath bin)
 .PHONY: generate-openapi-client
 generate-openapi-client: bin/goimports
 	rm -rf ./pkg/client/*.go docs
-	docker-compose -f ./docker-compose.yml run --rm \
+	docker compose -f ./docker-compose.yml run --rm \
 		jq -M -f filter.jq internal/spec/openapi.json > internal/openapi-generator/api/openapi-modified.json
-	docker-compose -f ./docker-compose.yml run --rm \
+	docker compose -f ./docker-compose.yml run --rm \
 		openapi-generator generate \
 			-g go \
 			-i internal/openapi-generator/api/openapi-modified.json \

--- a/scripts/git-askpass.sh
+++ b/scripts/git-askpass.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# GIT_ASKPASS script for git authentication. Reads credentials from
+# environment variables so the token is never written to disk.
+set -euo pipefail
+
+# Get the script directory to find helper functions
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/lib/actions-helpers.sh"
+
+if [ -z "$GIT_USER" ] || [ -z "$GIT_PASSWORD" ]; then
+  log_error "GIT_USER and GIT_PASSWORD are required"
+  exit 1
+fi
+
+case "$1" in
+  Username*) echo "$GIT_USER" ;;
+  Password*) echo "$GIT_PASSWORD" ;;
+esac

--- a/scripts/lib/openapi-sync-helpers-test.sh
+++ b/scripts/lib/openapi-sync-helpers-test.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# Tests for openapi-sync-helpers.sh functions
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR/.."
+source ./test-helpers.sh
+source ./lib/actions-helpers.sh
+source ./lib/validation.sh
+source ./lib/openapi-sync-helpers.sh
+
+# --- parse_managed_service_pr_url tests ---
+
+test_parse_pr_url_valid() {
+  MANAGED_SERVICE_PR_URL="https://github.com/cockroachlabs/managed-service/pull/1234"
+  parse_managed_service_pr_url
+  [ "$MS_OWNER" = "cockroachlabs" ] && \
+  [ "$MS_REPO" = "managed-service" ] && \
+  [ "$MS_PR_NUMBER" = "1234" ]
+}
+expect_success "parse_managed_service_pr_url: parses valid URL" test_parse_pr_url_valid
+
+test_parse_pr_url_different_repo() {
+  MANAGED_SERVICE_PR_URL="https://github.com/myorg/myrepo/pull/123"
+  parse_managed_service_pr_url 2>&1
+}
+expect_failure "parse_managed_service_pr_url: rejects URL from different repo" test_parse_pr_url_different_repo
+
+test_parse_pr_url_no_pr() {
+  MANAGED_SERVICE_PR_URL="https://github.com/cockroachlabs/managed-service"
+  parse_managed_service_pr_url 2>&1
+}
+expect_failure "parse_managed_service_pr_url: rejects URL without /pull/" test_parse_pr_url_no_pr
+
+test_parse_pr_url_malformed() {
+  MANAGED_SERVICE_PR_URL="not-a-url"
+  parse_managed_service_pr_url 2>&1
+}
+expect_failure "parse_managed_service_pr_url: rejects malformed URL" test_parse_pr_url_malformed
+
+# --- validate_event_payload tests ---
+
+test_validate_event_payload_valid_changed_event() {
+  (
+    export EVENT_TYPE="openapi-spec-changed"
+    export MANAGED_SERVICE_PR_URL="https://github.com/cockroachlabs/managed-service/pull/123"
+    validate_event_payload
+  )
+}
+expect_success "validate_event_payload: accepts valid changed event" test_validate_event_payload_valid_changed_event
+
+test_validate_event_payload_invalid_event_type() {
+  (
+    export EVENT_TYPE="invalid-event"
+    export MANAGED_SERVICE_PR_URL="https://github.com/cockroachlabs/managed-service/pull/123"
+    validate_event_payload 2>&1
+  )
+}
+expect_failure "validate_event_payload: rejects invalid EVENT_TYPE" test_validate_event_payload_invalid_event_type
+
+test_validate_event_payload_merged_event_requires_sha() {
+  (
+    export EVENT_TYPE="openapi-spec-merged"
+    export MANAGED_SERVICE_PR_URL="https://github.com/cockroachlabs/managed-service/pull/123"
+    validate_event_payload 2>&1
+  )
+}
+expect_failure "validate_event_payload: merged event requires MANAGED_SERVICE_SHA" test_validate_event_payload_merged_event_requires_sha
+
+test_validate_event_payload_merged_event_with_sha() {
+  (
+    export EVENT_TYPE="openapi-spec-merged"
+    export MANAGED_SERVICE_PR_URL="https://github.com/cockroachlabs/managed-service/pull/123"
+    export MANAGED_SERVICE_SHA="abc123def456"
+    validate_event_payload
+  )
+}
+expect_success "validate_event_payload: merged event succeeds with SHA" test_validate_event_payload_merged_event_with_sha
+
+test_validate_event_payload_changed_event_rejects_sha() {
+  (
+    export EVENT_TYPE="openapi-spec-changed"
+    export MANAGED_SERVICE_PR_URL="https://github.com/cockroachlabs/managed-service/pull/123"
+    export MANAGED_SERVICE_SHA="abc123def456"
+    validate_event_payload 2>&1
+  )
+}
+expect_failure "validate_event_payload: changed event rejects SHA" test_validate_event_payload_changed_event_rejects_sha
+
+print_results

--- a/scripts/lib/openapi-sync-helpers.sh
+++ b/scripts/lib/openapi-sync-helpers.sh
@@ -1,0 +1,512 @@
+#!/usr/bin/env bash
+# Helper functions for OpenAPI sync workflow
+
+# Set up git authentication using GIT_ASKPASS
+setup_git_auth() {
+  local user="$1"
+  local password="$2"
+  export GIT_ASKPASS="$SCRIPT_DIR/git-askpass.sh"
+  export GIT_USER="$user"
+  export GIT_PASSWORD="$password"
+  export GIT_TERMINAL_PROMPT=0
+}
+
+# Find an SDK PR that corresponds to a managed-service PR URL.
+#
+# This searches all open PRs in the current repository and inspects
+# all commits in each PR to find one containing a trailer:
+#   Managed-service-pr-url: <pr_url>
+#
+# Args: $1 - managed-service PR URL
+# Exports on success:
+#   SDK_PR_NUMBER: The SDK PR number
+#   HEAD_BRANCH: The SDK PR head branch name
+#   BASE_BRANCH: The SDK PR base branch name
+# Returns: 0 if found, 1 if not found
+find_sdk_pr() {
+  local managed_service_pr_url="$1"
+
+  if [[ -z "${managed_service_pr_url:-}" ]]; then
+    log_error "managed_service_pr_url is required"
+    return 1
+  fi
+
+  check_required_env GH_TOKEN GITHUB_REPOSITORY || return 1
+
+  log_info "Searching for SDK PR corresponding to: $managed_service_pr_url"
+
+  # Get all open SDK PRs
+  local sdk_open_prs
+  sdk_open_prs=$(gh pr list --repo "$GITHUB_REPOSITORY" --state open --json number --jq '.[].number')
+
+  for sdk_pr_num in $sdk_open_prs; do
+    log_info "Checking SDK PR #$sdk_pr_num"
+
+    # Get all commits in this SDK PR
+    local sdk_commits
+    sdk_commits=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$sdk_pr_num/commits" --jq '.[].sha')
+
+    # Check each commit's message for the trailer
+    for sdk_commit_sha in $sdk_commits; do
+      local sdk_commit_msg
+      sdk_commit_msg=$(gh api "repos/$GITHUB_REPOSITORY/git/commits/$sdk_commit_sha" --jq '.message')
+
+      if echo "$sdk_commit_msg" | grep --quiet --fixed-strings "Managed-service-pr-url: $managed_service_pr_url"; then
+        log_info "Found matching SDK PR #$sdk_pr_num (commit $sdk_commit_sha)"
+
+        # Get the SDK PR details
+        local pr_data
+        pr_data=$(gh pr view "$sdk_pr_num" --repo "$GITHUB_REPOSITORY" --json headRefName,baseRefName)
+
+        # Export results
+        export SDK_PR_NUMBER="$sdk_pr_num"
+        export HEAD_BRANCH=$(echo "$pr_data" | jq --raw-output '.headRefName')
+        export BASE_BRANCH=$(echo "$pr_data" | jq --raw-output '.baseRefName')
+        return 0
+      fi
+    done
+  done
+
+  log_info "No matching SDK PR found"
+  return 1
+}
+
+# Validate event payload business rules
+validate_event_payload() {
+  # Validate event_type is one of the allowed values
+  if [[ "$EVENT_TYPE" != "openapi-spec-changed" && "$EVENT_TYPE" != "openapi-spec-merged" ]]; then
+    log_error "Invalid 'event_type': $EVENT_TYPE. Must be 'openapi-spec-changed' or 'openapi-spec-merged'"
+    exit 1
+  fi
+
+  if [[ "$EVENT_TYPE" == "openapi-spec-merged" && -z "${MANAGED_SERVICE_SHA:-}" ]]; then
+    log_error "Input 'sha' is required for openapi-spec-merged event"
+    exit 1
+  fi
+
+  if [[ "$EVENT_TYPE" == "openapi-spec-changed" && -n "${MANAGED_SERVICE_SHA:-}" ]]; then
+    log_error "Input 'sha' should not be provided for openapi-spec-changed event"
+    exit 1
+  fi
+}
+
+# Parse managed-service PR metadata from URL
+#
+# Validates that the URL is from cockroachlabs/managed-service and extracts
+# the PR number.
+#
+# Exports:
+#   MS_OWNER: The GitHub organization
+#   MS_REPO: The repository name
+#   MS_PR_NUMBER: The managed-service PR number
+parse_managed_service_pr_url() {
+  MS_OWNER="cockroachlabs"
+  MS_REPO="managed-service"
+
+  # Validate URL format and extract PR number
+  if [[ ! "$MANAGED_SERVICE_PR_URL" =~ github\.com/$MS_OWNER/$MS_REPO/pull/([0-9]+) ]]; then
+    log_error "Invalid 'pr_url'. Must be a valid GitHub PR URL from $MS_OWNER/$MS_REPO"
+    exit 1
+  fi
+
+  MS_PR_NUMBER="${BASH_REMATCH[1]}"
+
+  log_info "Managed-service PR: $MS_OWNER/$MS_REPO#$MS_PR_NUMBER"
+
+  # Export for use in other functions
+  export MS_OWNER MS_REPO MS_PR_NUMBER
+}
+
+# Configure Git
+configure_git() {
+  git config user.name "$FORK_OWNER"
+  git config user.email "$FORK_OWNER@users.noreply.github.com"
+
+  FORK_URL="https://github.com/$FORK_OWNER/$(basename "$GITHUB_REPOSITORY").git"
+  log_info "Adding fork remote: $FORK_URL"
+  git remote add fork "$FORK_URL"
+
+  # Get the default branch name
+  local default_branch
+  default_branch=$(gh repo view "$GITHUB_REPOSITORY" --json defaultBranchRef --jq '.defaultBranchRef.name')
+  log_info "Default branch: $default_branch"
+
+  # Sync fork's default branch with upstream to include any changes from upstream
+  # that the fork doesn't have. This prevents feature branches from appearing to add
+  # files requiring special permissions (e.g., workflows), which would cause permission issues
+  log_info "Syncing fork's $default_branch with origin/$default_branch"
+
+  # Set up askpass for fork push
+  setup_git_auth "$FORK_OWNER" "$FORK_PUSH_TOKEN"
+
+  git push --force fork "origin/$default_branch:$default_branch"
+}
+
+# Determine head and base branches for the SDK PR
+# For existing SDK PRs: uses the PR's head branch and base branch
+# For new SDK PRs: finds/creates a base branch, then creates a new head branch from it
+# on openapi-spec-changed: may create a new head branch if no SDK PR exists yet
+# on openapi-spec-merged: the SDK PR must already exist
+#
+# Exports:
+#   HEAD_BRANCH: The SDK PR head branch name
+#   BASE_BRANCH: The SDK PR base branch name (target branch)
+#   EXISTING_SDK_PR: "true" if updating existing PR, "false" if creating new PR
+determine_head_and_base_branches() {
+  # Search all open PRs for one with a commit containing the managed-service PR URL
+  if find_sdk_pr "$MANAGED_SERVICE_PR_URL"; then
+    log_info "Using existing SDK PR branch: $HEAD_BRANCH (targets $BASE_BRANCH)"
+
+    # Set up askpass for fork operations
+    setup_git_auth "$FORK_OWNER" "$FORK_PUSH_TOKEN"
+
+    if ! git fetch fork "$HEAD_BRANCH" 2>&1; then
+      log_error "Could not fetch branch $HEAD_BRANCH from fork"
+      exit 1
+    fi
+    git checkout -B "$HEAD_BRANCH" "fork/$HEAD_BRANCH"
+
+    # Fetch the base branch from origin so Claude can diff against the latest state
+    setup_git_auth "x-access-token" "$GH_TOKEN"
+    git fetch origin "$BASE_BRANCH"
+
+    EXISTING_SDK_PR="true"
+  else
+    # No existing SDK PR found
+    if [[ "$EVENT_TYPE" == "openapi-spec-merged" ]]; then
+      # For merged events, we expect an SDK PR to already exist from the earlier
+      # openapi-spec-changed event. If not found, something went wrong.
+      log_error "No SDK PR found for openapi-spec-merged event"
+      exit 1
+    fi
+
+    # For changed events, create a new branch for a new SDK PR
+    # First, find or create the base branch (pending deploy branch)
+    find_pending_deploy_branch
+    BASE_BRANCH="$PENDING_DEPLOY_BRANCH"
+
+    TIMESTAMP=$(date --utc +%Y%m%d-%H%M%S)
+    HEAD_BRANCH="automation/openapi-spec-change-$TIMESTAMP"
+    log_info "Creating new head branch: $HEAD_BRANCH from $BASE_BRANCH"
+
+    # Set up askpass for origin operations
+    setup_git_auth "x-access-token" "$GH_TOKEN"
+
+    git fetch origin "$BASE_BRANCH"
+    git checkout -b "$HEAD_BRANCH" "origin/$BASE_BRANCH"
+
+    EXISTING_SDK_PR="false"
+  fi
+
+  export HEAD_BRANCH BASE_BRANCH EXISTING_SDK_PR
+}
+
+# Sync OpenAPI spec and regenerate client
+# Fetches the spec from managed-service and regenerates SDK client code.
+# For openapi-spec-changed events: fetch from PR branch
+# For openapi-spec-merged events: fetch from the exact merged commit SHA
+#
+# Exports:
+#   HAS_CHANGES: "true" if spec/client changed, "false" otherwise
+sync_and_regenerate() {
+  SPEC_PATH_IN_MS="console/ui/cc-console/assets/docs/api/latest/openapi.json"
+  LOCAL_SPEC_PATH="internal/spec/openapi.json"
+  LOCAL_SPEC_PATH_NEW="$LOCAL_SPEC_PATH.new"
+
+  # Use commit SHA if provided (merged event), otherwise use PR head (changed event)
+  if [[ -n "${MANAGED_SERVICE_SHA:-}" ]]; then
+    REF="$MANAGED_SERVICE_SHA"
+    log_info "Fetching openapi.json from $MS_OWNER/$MS_REPO at commit $MANAGED_SERVICE_SHA"
+  else
+    REF="refs/pull/$MS_PR_NUMBER/head"
+    log_info "Fetching openapi.json from $MS_OWNER/$MS_REPO PR #$MS_PR_NUMBER"
+  fi
+
+  # Fetch the OpenAPI spec file from managed-service
+  GH_TOKEN="$MANAGED_SERVICE_TOKEN" gh api "repos/$MS_OWNER/$MS_REPO/contents/$SPEC_PATH_IN_MS?ref=$REF" \
+    --jq '.content' | base64 --decode > "$LOCAL_SPEC_PATH_NEW"
+
+  # Validate the downloaded file is valid JSON
+  if ! jq empty "$LOCAL_SPEC_PATH_NEW"; then
+    log_error "Downloaded spec file is not valid JSON"
+    rm "$LOCAL_SPEC_PATH_NEW"
+    exit 1
+  fi
+
+  # Compare with current spec to see if anything changed
+  if cmp --silent "$LOCAL_SPEC_PATH" "$LOCAL_SPEC_PATH_NEW"; then
+    log_info "No changes to $LOCAL_SPEC_PATH"
+    rm "$LOCAL_SPEC_PATH_NEW"
+    HAS_CHANGES="false"
+  else
+    # Spec changed - replace it and regenerate the client code
+    log_info "Spec file changed, replacing $LOCAL_SPEC_PATH"
+    mv "$LOCAL_SPEC_PATH_NEW" "$LOCAL_SPEC_PATH"
+
+    # Regenerate SDK client from the new spec using Docker
+    # Note: sudo is required because docker containers run as root by default,
+    # creating files owned by root. We then chown them back to the current user.
+    log_info "Running make generate-openapi-client"
+    sudo make generate-openapi-client
+    sudo chown --recursive "$(id --user):$(id --group)" internal/openapi-generator/ pkg/client/ docs/ README.md
+
+    # Validate the generated code compiles
+    log_info "Validating generated code..."
+    if ! make validate; then
+      log_error "Generated code failed validation"
+      exit 1
+    fi
+
+    # Check if regeneration produced any changes
+    if [[ -z "$(git status --porcelain)" ]]; then
+      HAS_CHANGES="false"
+    else
+      HAS_CHANGES="true"
+    fi
+  fi
+
+  export HAS_CHANGES
+}
+
+# Update changelog with Claude
+# Uses Claude AI to analyze the git diff, update CHANGELOG.md, and generate
+# commit/PR metadata (title, body, description).
+#
+# Exports:
+#   COMMIT_TITLE: Generated commit title
+#   COMMIT_BODY: Generated commit body
+#   PR_TITLE: Generated PR title
+#   PR_DESCRIPTION: Generated PR description
+update_changelog() {
+  if [[ "$HAS_CHANGES" != "true" ]]; then
+    return
+  fi
+
+  # Reset CHANGELOG.md to base branch to avoid stale entries in the diff
+  # This ensures Claude only sees NEW changes when analyzing git diff
+  # Claude will then generate fresh changelog entries based on the actual changes
+  log_info "Resetting CHANGELOG.md to base branch to remove stale entries"
+  git checkout "origin/$BASE_BRANCH" -- CHANGELOG.md
+
+  log_info "Setting up Claude CLI..."
+  curl --fail --silent --show-error --location https://claude.ai/install.sh | bash -s -- "latest"
+  log_info "Claude CLI installed: $(claude --version)"
+
+  # Check for required commands
+  check_required_commands "claude" || return 1
+
+  # Configure Claude to use Vertex AI for authentication
+  log_info "Invoking Claude to update changelog..."
+  export CLAUDE_CODE_USE_VERTEX="1"
+  export ANTHROPIC_VERTEX_PROJECT_ID="vertex-model-runners"
+  export CLOUD_ML_REGION="us-east5"
+  export BASE_BRANCH
+
+  local prompt_file="$SCRIPT_DIR/../.claude/skills/generate-sync-metadata.md"
+
+  if [[ ! -f "$prompt_file" ]]; then
+    log_error "Prompt file not found at $prompt_file"
+    return 1
+  fi
+
+  # Create temp file for output
+  local output_file=$(mktemp)
+  trap "rm -f \"$output_file\"" EXIT RETURN
+
+  # Call Claude CLI
+  # WARNING: Do not modify --allowedTools without security review.
+  # These restrictions sandbox Claude to only edit CHANGELOG.md and run specific git commands.
+  log_info "Calling Claude CLI..."
+  claude --print \
+    --model claude-opus-4-6 \
+    --output-format json \
+    --max-turns 15 \
+    --allowedTools "Read,Edit(CHANGELOG.md),Bash(git:diff:*),Bash(printenv BASE_BRANCH)" \
+    < "$prompt_file" \
+    > "$output_file" 2>&1 || {
+      log_error "Claude CLI failed"
+      cat "$output_file" >&2
+      return 1
+    }
+
+  # Extract result text from JSON
+  local result_text
+  result_text=$(jq --raw-output '.result // empty' "$output_file")
+
+  if [[ -z "${result_text:-}" ]]; then
+    log_error "Claude produced empty result"
+    cat "$output_file" >&2
+    return 1
+  fi
+
+  log_info "Claude response received, extracting metadata..."
+
+  # Extract commit title (between ---COMMIT_TITLE--- and ---COMMIT_BODY---)
+  COMMIT_TITLE=$(echo "$result_text" | awk '/---COMMIT_TITLE---/{flag=1;next}/---COMMIT_BODY---/{flag=0}flag' | grep --invert-match '^[[:space:]]*$' | head --lines=1)
+
+  # Extract commit body (between ---COMMIT_BODY--- and ---PR_TITLE---)
+  COMMIT_BODY=$(echo "$result_text" | awk '/---COMMIT_BODY---/{flag=1;next}/---PR_TITLE---/{flag=0}flag')
+
+  # Extract PR title (between ---PR_TITLE--- and ---PR_DESCRIPTION---)
+  PR_TITLE=$(echo "$result_text" | awk '/---PR_TITLE---/{flag=1;next}/---PR_DESCRIPTION---/{flag=0}flag' | grep --invert-match '^[[:space:]]*$' | head --lines=1)
+
+  # Extract PR description (after ---PR_DESCRIPTION---)
+  PR_DESCRIPTION=$(echo "$result_text" | awk '/---PR_DESCRIPTION---/{flag=1;next}flag')
+
+  # Validate extractions
+  if [[ -z "${COMMIT_TITLE:-}" ]]; then
+    log_error "Could not extract commit title from Claude output"
+    echo "Claude output:" >&2
+    echo "$result_text" >&2
+    return 1
+  fi
+
+  if [[ -z "${PR_TITLE:-}" ]]; then
+    log_error "Could not extract PR title from Claude output"
+    echo "Claude output:" >&2
+    echo "$result_text" >&2
+    return 1
+  fi
+
+  log_info "Metadata extracted successfully"
+
+  # Export results
+  export COMMIT_TITLE COMMIT_BODY PR_TITLE PR_DESCRIPTION
+}
+
+# Commit changes
+commit_changes() {
+  if [[ "$HAS_CHANGES" != "true" ]]; then
+    if [[ "$EVENT_TYPE" == "openapi-spec-merged" ]]; then
+      # Scenario: The managed-service PR was merged, but the spec hasn't changed
+      # since our last sync. We still need to add the managed-service commit SHA
+      # to the SDK commit message to track which managed-service commit this SDK
+      # change corresponds to.
+      # Note: This only runs on open SDK PRs - if the SDK PR was already merged,
+      # find_sdk_pr would have failed and exited earlier.
+      log_info "No changes detected, but adding SHA trailer to existing commit"
+      git commit --amend --no-edit \
+        --trailer "Managed-service-commit-SHA: ${MANAGED_SERVICE_SHA}"
+    fi
+    return
+  fi
+
+  # Stage all generated files and the updated CHANGELOG
+  git add internal/spec/openapi.json \
+          internal/openapi-generator/api/openapi-modified.json \
+          internal/openapi-generator/api/openapi.yaml \
+          internal/openapi-generator/.openapi-generator/FILES \
+          pkg/client/ \
+          docs/ \
+          README.md \
+          CHANGELOG.md
+
+  # Build base commit message (title + body)
+  COMMIT_MSG=$(printf "%s\n\n%s" "$COMMIT_TITLE" "$COMMIT_BODY")
+
+  # For existing PRs: amend the previous OpenAPI sync commit
+  # For new PRs: create a new commit on top of the base branch
+  if [[ "$EXISTING_SDK_PR" == "true" ]]; then
+    log_info "Amending existing commit"
+    git commit --amend --message "$COMMIT_MSG" \
+      --trailer "Managed-service-pr-url: ${MANAGED_SERVICE_PR_URL}"
+  else
+    log_info "Creating new commit"
+    git commit --message "$COMMIT_MSG" \
+      --trailer "Managed-service-pr-url: ${MANAGED_SERVICE_PR_URL}"
+  fi
+
+  # Add SHA trailer if provided
+  if [[ -n "${MANAGED_SERVICE_SHA:-}" ]]; then
+    git commit --amend --no-edit \
+      --trailer "Managed-service-commit-SHA: ${MANAGED_SERVICE_SHA}"
+  fi
+}
+
+# Push to fork
+# Pushes the head branch to the bot's fork. Uses force-with-lease when updating
+# existing PRs (since we amend commits), regular push for new branches.
+push_to_fork() {
+  if [[ "$HAS_CHANGES" != "true" && "$EVENT_TYPE" != "openapi-spec-merged" ]]; then
+    return
+  fi
+
+  setup_git_auth "$FORK_OWNER" "$FORK_PUSH_TOKEN"
+
+  # Use force-with-lease for existing PRs (we amended the commit)
+  # Use regular push for new branches
+  if [[ "$EXISTING_SDK_PR" == "true" ]] || [[ "$EVENT_TYPE" == "openapi-spec-merged" ]]; then
+    log_info "Force-pushing to existing branch: $HEAD_BRANCH"
+    git push --force-with-lease fork "$HEAD_BRANCH"
+  else
+    log_info "Pushing new branch: $HEAD_BRANCH"
+    git push --set-upstream fork "$HEAD_BRANCH"
+  fi
+}
+
+# Find or create pending deploy branch
+# New SDK PRs target an automation/pending-deploy-* branch (not main) to batch multiple
+# changes together before release. Reuses the most recent automation/pending-deploy branch
+# if one exists, otherwise creates a new one from main.
+#
+# Exports:
+#   PENDING_DEPLOY_BRANCH: The pending deploy branch name
+find_pending_deploy_branch() {
+  log_info "Looking for active pending deploy branch..."
+
+  # Find all automation/pending-deploy branches, sorted newest first
+  PENDING_BRANCHES=$(gh api "repos/$GITHUB_REPOSITORY/branches" \
+    --jq '.[] | select(.name | startswith("automation/pending-deploy-")) | .name' | \
+    sort --reverse)
+
+  if [[ -n "$PENDING_BRANCHES" ]]; then
+    # Reuse the most recent automation/pending-deploy branch
+    PENDING_DEPLOY_BRANCH=$(echo "$PENDING_BRANCHES" | head --lines=1)
+    log_info "Found existing pending deploy branch: $PENDING_DEPLOY_BRANCH"
+  else
+    # No automation/pending-deploy branch exists, create a new one from main
+    TIMESTAMP=$(date --utc +%Y%m%d-%H%M%S)
+    PENDING_DEPLOY_BRANCH="automation/pending-deploy-$TIMESTAMP"
+    log_info "Creating new pending deploy branch: $PENDING_DEPLOY_BRANCH"
+
+    MAIN_SHA=$(gh api "repos/$GITHUB_REPOSITORY/git/ref/heads/main" --jq '.object.sha')
+    gh api "repos/$GITHUB_REPOSITORY/git/refs" \
+      --method POST \
+      --field ref="refs/heads/$PENDING_DEPLOY_BRANCH" \
+      --field sha="$MAIN_SHA"
+  fi
+
+  export PENDING_DEPLOY_BRANCH
+}
+
+# Create or update PR
+# Creates a new SDK PR targeting the base branch or updates an existing PR's
+# title and description with the latest from Claude.
+create_or_update_pr() {
+  if [[ "$HAS_CHANGES" != "true" ]]; then
+    return
+  fi
+
+  if [[ "$EXISTING_SDK_PR" == "true" ]]; then
+    # Update the existing PR's title and description
+    log_info "Updating existing SDK PR #$SDK_PR_NUMBER"
+
+    gh api --method PATCH "repos/$GITHUB_REPOSITORY/pulls/$SDK_PR_NUMBER" \
+      --field title="$PR_TITLE" \
+      --field body="$PR_DESCRIPTION"
+
+    log_info "SDK PR updated: https://github.com/$GITHUB_REPOSITORY/pull/$SDK_PR_NUMBER"
+  else
+    # Create a new PR from the fork to the base branch
+    log_info "Creating new SDK PR from $FORK_OWNER:$HEAD_BRANCH to $GITHUB_REPOSITORY:$BASE_BRANCH"
+
+    gh pr create \
+      --repo "$GITHUB_REPOSITORY" \
+      --head "$FORK_OWNER:$HEAD_BRANCH" \
+      --base "$BASE_BRANCH" \
+      --title "$PR_TITLE" \
+      --body "$PR_DESCRIPTION"
+
+    log_info "SDK PR created successfully"
+  fi
+}

--- a/scripts/openapi-sync-generate.sh
+++ b/scripts/openapi-sync-generate.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Generate updated SDK client from OpenAPI spec.
+#
+# This script:
+# 1. Validates event payload
+# 2. Parses managed-service PR metadata
+# 3. Configures Git
+# 4. Determines head and base branches (finds existing SDK PR or creates new branches)
+# 5. Fetches OpenAPI spec and regenerates client code
+#
+# Environment variables:
+#   EVENT_TYPE: Type of event triggering the sync (openapi-spec-changed or openapi-spec-merged)
+#   MANAGED_SERVICE_PR_URL: URL of the managed-service PR containing spec changes
+#   MANAGED_SERVICE_SHA: Commit SHA in managed-service to fetch spec from (merged events only)
+#   MANAGED_SERVICE_TOKEN: GitHub token with read access to managed-service repo (secret)
+#   FORK_PUSH_TOKEN: GitHub token with push access to bot fork (secret)
+#   FORK_OWNER: GitHub username of the bot fork owner
+#   GH_TOKEN: GitHub token for gh CLI operations (secret)
+#   GITHUB_REPOSITORY: Current repository in owner/repo format
+
+# Get the script directory
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Source helper functions
+source "$SCRIPT_DIR/lib/actions-helpers.sh"
+source "$SCRIPT_DIR/lib/validation.sh"
+source "$SCRIPT_DIR/lib/openapi-sync-helpers.sh"
+
+# Main execution
+main() {
+  log_info "=== Starting OpenAPI sync step: Generate ==="
+  log_info "Event type: $EVENT_TYPE"
+  log_info "PR URL: $MANAGED_SERVICE_PR_URL"
+  log_info "SHA: ${MANAGED_SERVICE_SHA:-<not provided>}"
+
+  check_required_commands "gh" "git" "jq" "make" || exit 1
+  check_required_env "EVENT_TYPE" "MANAGED_SERVICE_PR_URL" "MANAGED_SERVICE_TOKEN" \
+    "FORK_PUSH_TOKEN" "FORK_OWNER" "GH_TOKEN" "GITHUB_REPOSITORY" || exit 1
+  validate_event_payload
+  parse_managed_service_pr_url
+  configure_git
+  determine_head_and_base_branches
+  sync_and_regenerate
+
+  # Export outputs for subsequent steps
+  {
+    echo "base_branch=$BASE_BRANCH"
+    echo "has_changes=$HAS_CHANGES"
+    echo "existing_sdk_pr=$EXISTING_SDK_PR"
+    echo "head_branch=$HEAD_BRANCH"
+    echo "sdk_pr_number=${SDK_PR_NUMBER:-}"
+  } >> "$GITHUB_OUTPUT"
+
+  log_info "=== OpenAPI sync step completed: Generate ==="
+}
+
+main

--- a/scripts/openapi-sync-publish.sh
+++ b/scripts/openapi-sync-publish.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Publish OpenAPI sync changes.
+#
+# This script:
+# 1. Commits changes with generated metadata
+# 2. Pushes to fork
+# 3. Creates or updates SDK PR
+#
+# Environment variables:
+#   EVENT_TYPE: Type of event triggering the sync (openapi-spec-changed or openapi-spec-merged)
+#   MANAGED_SERVICE_PR_URL: URL of the managed-service PR containing spec changes
+#   MANAGED_SERVICE_SHA: Commit SHA in managed-service (merged events only)
+#   FORK_OWNER: GitHub username of the bot fork owner
+#   FORK_PUSH_TOKEN: GitHub token with push access to bot fork (secret)
+#   GH_TOKEN: GitHub token for gh CLI operations (secret)
+#   GITHUB_REPOSITORY: Current repository in owner/repo format
+#   BASE_BRANCH: Base branch for the SDK PR
+#   HAS_CHANGES: Whether there are changes to commit
+#   EXISTING_SDK_PR: Whether updating existing PR or creating new one
+#   HEAD_BRANCH: Head branch name for the SDK PR
+#   SDK_PR_NUMBER: SDK PR number (when updating existing PR)
+#   COMMIT_TITLE: Generated commit title (when there are changes)
+#   COMMIT_BODY: Generated commit body (when there are changes)
+#   PR_TITLE: Generated PR title (when there are changes)
+#   PR_DESCRIPTION: Generated PR description (when there are changes)
+
+# Get the script directory
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Source helper functions
+source "$SCRIPT_DIR/lib/actions-helpers.sh"
+source "$SCRIPT_DIR/lib/validation.sh"
+source "$SCRIPT_DIR/lib/openapi-sync-helpers.sh"
+
+# Main execution
+main() {
+  log_info "=== Starting OpenAPI sync step: Publish ==="
+
+  check_required_commands "gh" "git" || exit 1
+  check_required_env "EVENT_TYPE" "MANAGED_SERVICE_PR_URL" "FORK_OWNER" \
+    "FORK_PUSH_TOKEN" "GH_TOKEN" "GITHUB_REPOSITORY" "BASE_BRANCH" \
+    "HAS_CHANGES" "EXISTING_SDK_PR" "HEAD_BRANCH" || exit 1
+  commit_changes
+  push_to_fork
+  create_or_update_pr
+
+  if [[ "$HAS_CHANGES" == "false" && "$EVENT_TYPE" != "openapi-spec-merged" ]]; then
+    log_info "No changes detected after syncing OpenAPI spec and regenerating client"
+  fi
+
+  log_info "=== OpenAPI sync step completed: Publish ==="
+}
+
+main

--- a/scripts/openapi-sync-update-changelog.sh
+++ b/scripts/openapi-sync-update-changelog.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Update changelog with Claude.
+#
+# This script uses Claude AI to analyze the git diff, update CHANGELOG.md,
+# and generate commit/PR metadata (title, body, description).
+#
+# Environment variables:
+#   BASE_BRANCH: Base branch to diff against
+#   HAS_CHANGES: Whether there are changes to process
+
+# Get the script directory
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Source helper functions
+source "$SCRIPT_DIR/lib/actions-helpers.sh"
+source "$SCRIPT_DIR/lib/validation.sh"
+source "$SCRIPT_DIR/lib/openapi-sync-helpers.sh"
+
+# Main execution
+main() {
+  log_info "=== Starting OpenAPI sync step: Update changelog ==="
+
+  check_required_commands "curl" || exit 1
+  check_required_env "BASE_BRANCH" "HAS_CHANGES" || exit 1
+  update_changelog
+
+  # Export outputs for subsequent steps
+  echo "commit_title=${COMMIT_TITLE:-}" >> "$GITHUB_OUTPUT"
+
+  {
+    echo "commit_body<<EOF"
+    echo "${COMMIT_BODY:-}"
+    echo "EOF"
+  } >> "$GITHUB_OUTPUT"
+
+  echo "pr_title=${PR_TITLE:-}" >> "$GITHUB_OUTPUT"
+
+  {
+    echo "pr_description<<EOF"
+    echo "${PR_DESCRIPTION:-}"
+    echo "EOF"
+  } >> "$GITHUB_OUTPUT"
+
+  log_info "=== OpenAPI sync step completed: Update changelog ==="
+}
+
+main

--- a/scripts/update_version.sh
+++ b/scripts/update_version.sh
@@ -17,11 +17,7 @@ source "$SCRIPT_DIR/lib/validation.sh"
 check_required_commands cut sed make
 
 # Check if VERSION environment variable is set
-if [ -z "$VERSION" ]; then
-    log_error "VERSION environment variable is required"
-    log_error "This script is intended to be called by the create-release-pr workflow"
-    exit 1
-fi
+check_required_env VERSION || exit 1
 
 log_info "Updating version to $VERSION in config and documentation files..."
 


### PR DESCRIPTION
This workflow automates synchronization of OpenAPI specs from the managed-service repository. When triggered via workflow_dispatch with `openapi-spec-changed` or `openapi-spec-merged` event types:

- Fetches the latest OpenAPI spec from the managed-service PR branch (for changed events) or from the specific commit SHA (for merged events)
- Regenerates SDK client code using make generate-openapi-client
- Invokes Claude AI (via Vertex AI) to analyze changes and update CHANGELOG.md with appropriate entries
- Creates or updates PR from bot fork to pending-deploy branch

The workflow includes scripts for finding corresponding SDK PRs and invoking Claude for changelog generation. The Claude prompt instructs it to analyze git diffs, update CHANGELOG.md following Keep a Changelog conventions, identify breaking changes, and output structured metadata for commit messages and PR descriptions.

----

## Testing

Did a mini bug bash testing the SDK release workflows end to end. Here are some test cases I tested for this workflow: https://docs.google.com/spreadsheets/d/1_SJbN6T9XU3_r01guk-KrCYoLQocs6ECaRNghr28X5At?gid=0#gid=0

Example PR opened by workflow 
- On `openapi-spec-changed` event: https://github.com/cockroachlabs/cockroach-cloud-sdk-go-automation-testing/pull/178
- On `openapi-spec-merged` event: https://github.com/cockroachlabs/cockroach-cloud-sdk-go-automation-testing/pull/179

Note: in the case of the _"merged"_ event, there's an additional trailer in the commit message