### PR TITLE
Fix release workflow to use workflow_dispatch for ccloud-private

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     outputs:
-      tag-created: ${{ steps.autotag.outputs.tag-created }}
+      tag_created: ${{ steps.autotag.outputs.tag_created }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -21,12 +21,12 @@ jobs:
       - uses: cockroachdb/actions/autotag-from-changelog@v0
         id: autotag
 
-      # Dispatches an sdk-release event to ccloud-private. Requires a
+      # Triggers the sync-cli-with-sdk workflow in ccloud-private. Requires a
       # CCLOUD_PRIVATE_DISPATCH_PAT secret — a fine-grained PAT with
-      # contents:write on cockroachdb/ccloud-private, since GITHUB_TOKEN
+      # actions:write on cockroachlabs/ccloud-private, since GITHUB_TOKEN
       # cannot trigger workflows in other repositories.
       - name: Dispatch to ccloud-private
-        if: steps.autotag.outputs.tag-created == 'true'
+        if: steps.autotag.outputs.tag_created == 'true'
         env:
           GH_TOKEN: ${{ secrets.CCLOUD_PRIVATE_DISPATCH_PAT }}
         run: |
@@ -36,9 +36,9 @@ jobs:
             log_warning "CCLOUD_PRIVATE_DISPATCH_PAT secret is required. Skipping dispatch to ccloud-private for ${{ steps.autotag.outputs.tag }}."
             exit 0
           fi
-          gh api repos/cockroachdb/ccloud-private/dispatches \
-            --field event_type=sdk-release \
-            --field "client_payload[version]=${{ steps.autotag.outputs.tag }}"
+          gh workflow run sync-cli-with-sdk.yml \
+            --repo cockroachlabs/ccloud-private \
+            --field sdk_version=${{ steps.autotag.outputs.tag }}
 
   # After a successful release, this job ensures there's always a fresh pending deploy
   # branch ready for the next release cycle. It:
@@ -49,7 +49,7 @@ jobs:
   # 4. Retargets all open PRs to point to the current pending deploy branch
   manage-pending-deploy:
     needs: release
-    if: needs.release.outputs.tag-created == 'true'
+    if: needs.release.outputs.tag_created == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   PRs that remain open after an SDK release are retargeted to the latest pending
   deploy branch
 
+### Changed
+
+- Updated release workflow to trigger ccloud-private CLI sync using workflow_dispatch
+  instead of repository_dispatch.
+
 ## [7.1.0] - 2026-04-14
 
 ### Added


### PR DESCRIPTION
The ccloud-private repo's sync-cli-with-sdk workflow uses workflow_dispatch, not repository_dispatch. This updates the release workflow to trigger it correctly using `gh workflow run` with the required sdk_version input.

Also fixes all references from tag-created to tag_created for consistency with the autotag-from-changelog action's output format.