### PR TITLE
Disable maintainer edits on OpenAPI sync PRs

### DIFF
--- a/scripts/lib/openapi-sync-helpers.sh
+++ b/scripts/lib/openapi-sync-helpers.sh
@@ -511,13 +511,20 @@ create_or_update_pr() {
     # Create a new PR from the fork to the base branch
     log_info "Creating new SDK PR from $FORK_OWNER:$HEAD_BRANCH to $GITHUB_REPOSITORY:$BASE_BRANCH"
 
+    # --no-maintainer-edit is required: GH_TOKEN is the upstream repo's
+    # workflow token and has no write access to the fork, so it cannot grant
+    # "Allow edits by maintainers" (fork collab). Without this flag, PR
+    # creation fails with "Fork collab can't be granted by someone without
+    # permission". Reviewers who need to push fixups can be added as
+    # collaborators on the fork instead.
     local pr_url
     pr_url=$(gh pr create \
       --repo "$GITHUB_REPOSITORY" \
       --head "$FORK_OWNER:$HEAD_BRANCH" \
       --base "$BASE_BRANCH" \
       --title "$PR_TITLE" \
-      --body "$PR_DESCRIPTION")
+      --body "$PR_DESCRIPTION" \
+      --no-maintainer-edit)
 
     log_info "SDK PR created: $pr_url"
 


### PR DESCRIPTION
gh pr create defaults to enabling "Allow edits by maintainers" on cross-fork PRs, which requires the requesting token to have write access to the head branch in the fork. The workflow uses github.token, which is scoped only to the upstream repo and cannot grant fork collaboration, causing PR creation to fail with:

  pull request create failed: GraphQL: Fork collab Fork collab can't
  be granted by someone without permission (createPullRequest)

Pass --no-maintainer-edit so the toggle is left off at creation time. Reviewers who need to push fixups can be added as collaborators on the bot fork instead.