### PR TITLE
Allow sed -n in OpenAPI sync Claude allowlist

### DIFF
--- a/scripts/lib/openapi-sync-helpers.sh
+++ b/scripts/lib/openapi-sync-helpers.sh
@@ -342,7 +342,7 @@ update_changelog() {
     --output-format stream-json \
     --verbose \
     --max-turns 15 \
-    --allowedTools "Read,Edit(CHANGELOG.md),Bash(git:diff:*),Bash(printenv BASE_BRANCH)" \
+    --allowedTools "Read,Edit(CHANGELOG.md),Bash(git:diff:*),Bash(printenv BASE_BRANCH),Bash(sed:-n:*)" \
     < "$prompt_file" \
     | tee "$output_file" || {
       echo "::endgroup::"


### PR DESCRIPTION
Large diffs get truncated to tool-result files; Claude needs read-only sed to extract sections, otherwise it burns turns on denied commands and hits max-turns.