### PR TITLE
Pre-generate git diff for Claude changelog step in OpenAPI sync

### DIFF
--- a/.claude/skills/generate-sync-metadata.md
+++ b/.claude/skills/generate-sync-metadata.md
@@ -1,13 +1,14 @@
 # Generate Sync Metadata
 
-This skill is ONLY for the automated OpenAPI sync workflow (scripts/openapi-sync.sh).
+This skill is ONLY for the automated OpenAPI sync workflow (scripts/openapi-sync-update-changelog.sh).
 Do not use this skill for manual changelog updates or other changelog work.
 
 Analyze the OpenAPI spec sync changes, update CHANGELOG.md, and generate structured metadata (commit title, commit body, PR title, PR description) for the sync.
 
 ## CRITICAL: Source of Truth
 
-**The git diff output is your ONLY source of truth.**
+**The diff file at `/tmp/openapi-sync-diff.txt` is your ONLY source of truth.**
+- `/tmp/openapi-sync-diff-stat.txt` is a file-by-file summary of that same diff, provided only as a navigation aid - do not document anything based on the summary alone
 - Document ONLY what appears in the diff - nothing more, nothing less
 - If something is not in the diff, do NOT document it
 - All changelog entries, commit messages, and PR descriptions must be based ONLY on what you see in the diff
@@ -15,12 +16,8 @@ Analyze the OpenAPI spec sync changes, update CHANGELOG.md, and generate structu
 ## Instructions
 
 **Step 1: View the changes**
-- Run `printenv BASE_BRANCH` and save the exact output value
-- Run `git diff origin/<BASE_BRANCH_VALUE>` where you substitute `<BASE_BRANCH_VALUE>` with the EXACT value from the printenv command
-  - Example: if printenv output "automation/pending-deploy-20260514-043826", run `git diff origin/automation/pending-deploy-20260514-043826`
-  - Example: if printenv output "main", run `git diff origin/main`
-- **DO NOT** run `git diff main` or `git diff origin/main` IF BASE_BRANCH is NOT `main`
-- **DO NOT** run `git log`, `git show`, or any other git command
+- Read `/tmp/openapi-sync-diff-stat.txt` for an overview of which files changed
+- Read `/tmp/openapi-sync-diff.txt` for the full diff. You'll need to read the entire diff to ensure you don't miss any changes. It may be large - use the Read tool's offset and limit parameters to page through it until you have seen all of it, reading as much as you can in each turn to save round trips. Do not stop after the first page.
 
 **Step 2: Update CHANGELOG.md**
 - Follow the changelog conventions documented in CLAUDE.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix the OpenAPI sync workflow's changelog generation step, which failed on large
+  syncs by pre-generating the git diff instead of having Claude run it.
+
 ## [8.0.0] - 2026-07-06
 
 ### Added

--- a/scripts/lib/openapi-sync-helpers.sh
+++ b/scripts/lib/openapi-sync-helpers.sh
@@ -116,8 +116,10 @@ parse_managed_service_pr_url() {
 
   # Look up PR author so we can request them as a reviewer on the SDK PR.
   # Best-effort: failures here must not abort the sync.
+  # On failure gh prints the error response body to stdout, so discard the
+  # captured value entirely rather than keeping it.
   MS_PR_AUTHOR=$(GH_TOKEN="$MANAGED_SERVICE_TOKEN" \
-    gh api "repos/$MS_OWNER/$MS_REPO/pulls/$MS_PR_NUMBER" --jq '.user.login' || true)
+    gh api "repos/$MS_OWNER/$MS_REPO/pulls/$MS_PR_NUMBER" --jq '.user.login') || MS_PR_AUTHOR=""
   if [[ -n "$MS_PR_AUTHOR" ]]; then
     log_info "Managed-service PR author: $MS_PR_AUTHOR"
   else
@@ -299,6 +301,14 @@ update_changelog() {
   log_info "Resetting CHANGELOG.md to base branch to remove stale entries"
   git checkout "origin/$BASE_BRANCH" -- CHANGELOG.md
 
+  # Pre-generate the diff for Claude to Read. Generating it here (rather than
+  # having Claude run git diff) lets the allowlist drop Bash entirely: the Read
+  # tool pages through large files natively, so Claude doesn't burn turns on
+  # shell pipelines to slice up an oversized diff.
+  log_info "Generating diff files for Claude"
+  git diff --stat "origin/$BASE_BRANCH" > /tmp/openapi-sync-diff-stat.txt
+  git diff "origin/$BASE_BRANCH" > /tmp/openapi-sync-diff.txt
+
   log_info "Setting up Claude CLI..."
   curl --fail --silent --show-error --location https://claude.ai/install.sh | bash -s -- "latest"
   log_info "Claude CLI installed: $(claude --version)"
@@ -311,7 +321,6 @@ update_changelog() {
   export CLAUDE_CODE_USE_VERTEX="1"
   export ANTHROPIC_VERTEX_PROJECT_ID="vertex-model-runners"
   export CLOUD_ML_REGION="us-east5"
-  export BASE_BRANCH
 
   local prompt_file="$SCRIPT_DIR/../.claude/skills/generate-sync-metadata.md"
 
@@ -326,7 +335,7 @@ update_changelog() {
 
   # Call Claude CLI
   # WARNING: Do not modify --allowedTools without security review.
-  # These restrictions sandbox Claude to only edit CHANGELOG.md and run specific git commands.
+  # These restrictions sandbox Claude to reading files and editing CHANGELOG.md only.
   #
   # --output-format stream-json --verbose emits one JSON event per turn (tool
   # call, tool result, assistant message, final result) instead of buffering a
@@ -341,8 +350,8 @@ update_changelog() {
     --model claude-opus-4-6 \
     --output-format stream-json \
     --verbose \
-    --max-turns 15 \
-    --allowedTools "Read,Edit(CHANGELOG.md),Bash(git:diff:*),Bash(printenv BASE_BRANCH),Bash(sed:-n:*)" \
+    --max-turns 30 \
+    --allowedTools "Read,Edit(CHANGELOG.md)" \
     < "$prompt_file" \
     | tee "$output_file" || {
       echo "::endgroup::"


### PR DESCRIPTION
The changelog step failed on every recent run: Claude ran git diff itself, the huge generated-client diff spilled into an oversized tool result, and Claude burned its 15 turns on shell pipelines that the allowlist rejected before it could edit CHANGELOG.md.

Generate the diff (plus a --stat summary) in the script and have Claude read the files directly instead. This removes the need for any Bash access, tightening the allowlist to Read and Edit(CHANGELOG.md), and raises --max-turns to 30 for headroom on large syncs.