### PR TITLE
[CNSL-2477] Automerge automated SDK PRs and request review

### DIFF
--- a/.github/workflows/openapi-sync.yml
+++ b/.github/workflows/openapi-sync.yml
@@ -91,6 +91,7 @@ jobs:
           HEAD_BRANCH: ${{ steps.sync.outputs.head_branch }}
           SDK_PR_NUMBER: ${{ steps.sync.outputs.sdk_pr_number }}
           MANAGED_SERVICE_PR_AUTHOR: ${{ steps.sync.outputs.managed_service_pr_author }}
+          AUTOMERGE_FAILURE_REVIEWERS: linhcrl,fantapop
           COMMIT_TITLE: ${{ steps.changelog.outputs.commit_title }}
           COMMIT_BODY: ${{ steps.changelog.outputs.commit_body }}
           PR_TITLE: ${{ steps.changelog.outputs.pr_title }}

--- a/.github/workflows/pending-deploy-pr.yml
+++ b/.github/workflows/pending-deploy-pr.yml
@@ -44,6 +44,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}
+          PENDING_DEPLOY_REVIEWERS: linhcrl,fantapop
         run: scripts/pending-deploy-pr.sh
 
       # GitHub Actions doesn't automatically trigger workflows when a PR is created using GITHUB_TOKEN

--- a/scripts/lib/actions-helpers.sh
+++ b/scripts/lib/actions-helpers.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Logging functions for GitHub Actions workflows
+# Shared helpers for GitHub Actions workflows
 
 # Output an informational message to stdout
 log_info() {
@@ -29,4 +29,30 @@ log_notice() {
 # Write a single-line output: set_output key value
 set_output() {
   echo "$1=$2" >> "${GITHUB_OUTPUT:-/dev/null}"
+}
+
+# Request review on a PR so it reaches a human; nobody is subscribed to a bot PR.
+#
+# Best-effort: callers report their own failures and the work that created the PR matters more.
+#
+# Args: $1 - PR number, $2 - comma-separated handles (no-op when empty)
+request_pr_reviewers() {
+  local pr_number="$1" reviewers="$2" args=() reviewer
+
+  if [[ -z "$reviewers" ]]; then
+    return
+  fi
+
+  # REST, not `gh pr edit --add-reviewer`: that resolves handles via GraphQL and needs `read:org`,
+  # which the workflow token lacks.
+  for reviewer in ${reviewers//,/ }; do
+    args+=(--field "reviewers[]=$reviewer")
+  done
+
+  if gh api --method POST \
+    "repos/$GITHUB_REPOSITORY/pulls/$pr_number/requested_reviewers" "${args[@]}" >/dev/null; then
+    log_info "Requested review on PR #$pr_number from $reviewers"
+  else
+    log_warning "Could not request review on PR #$pr_number from $reviewers"
+  fi
 }

--- a/scripts/lib/openapi-sync-helpers.sh
+++ b/scripts/lib/openapi-sync-helpers.sh
@@ -567,3 +567,120 @@ create_or_update_pr() {
     fi
   fi
 }
+
+# Post a comment on the SDK PR explaining why automerge could not complete.
+#
+# Args: $1 - human-readable reason
+post_automerge_failure_comment() {
+  local reason="$1"
+
+  # Never let a comment failure mask the automerge failure it is reporting: this script runs
+  # under `set -e` and the caller still needs to exit non-zero.
+  gh pr comment "$SDK_PR_NUMBER" --repo "$GITHUB_REPOSITORY" --body "$(cat <<EOF
+## Automerge Failed
+
+The managed-service PR has merged and this PR was updated, but it could not be merged into
+\`$BASE_BRANCH\` automatically:
+
+> $reason
+
+Resolve this manually and merge the PR.
+EOF
+)" || log_warning "Could not post automerge failure comment on SDK PR #$SDK_PR_NUMBER"
+}
+
+# Describe why the SDK PR could not be merged.
+#
+# Only accurate once automerge_sdk_pr's retries are exhausted; read earlier it races the force-push.
+#
+# Outputs: a reason on stdout
+describe_unmergeable_pr() {
+  local merge_state
+
+  # Discard stderr: a warning on a successful read would be appended to the status and send every
+  # state to the catch-all.
+  if ! merge_state=$(gh pr view "$SDK_PR_NUMBER" --repo "$GITHUB_REPOSITORY" \
+    --json mergeStateStatus --jq '.mergeStateStatus' 2>/dev/null); then
+    echo "GitHub did not report a merge state for the PR."
+    return
+  fi
+
+  case "$merge_state" in
+    DIRTY)
+      echo "The PR conflicts with \`$BASE_BRANCH\` and needs to be rebased onto it."
+      ;;
+    BLOCKED)
+      echo "Branch protection on \`$BASE_BRANCH\` is blocking the merge; a required review or status check is missing."
+      ;;
+    BEHIND)
+      echo "The PR is behind \`$BASE_BRANCH\` and branch protection requires it to be up to date before merging."
+      ;;
+    DRAFT)
+      echo "The PR is still marked as a draft."
+      ;;
+    *)
+      echo "GitHub reported mergeStateStatus \`$merge_state\`."
+      ;;
+  esac
+}
+
+# Rebase-merge the SDK PR into its pending deploy branch.
+#
+# Only runs for openapi-spec-merged events: by this point the managed-service PR has merged, the
+# SDK commit carries the Managed-service-commit-SHA trailer, and the branch has been pushed.
+#
+# Rebase, not squash or merge: pending-deploy-check reads the Managed-service-commit-SHA trailer
+# off every commit in origin/main..<pending deploy branch>, and only rebase replays commit messages
+# verbatim, so it is the only strategy that keeps the trailer intact.
+#
+# Returns: 0 if merged (or already resolved), 1 otherwise
+automerge_sdk_pr() {
+  check_required_env "SDK_PR_NUMBER" "GITHUB_REPOSITORY" "BASE_BRANCH" "GH_TOKEN" || return 1
+
+  local max_attempts=10
+  local retry_seconds=5
+
+  local head_sha
+  head_sha=$(git rev-parse HEAD)
+
+  log_info "Automerging SDK PR #$SDK_PR_NUMBER ($head_sha) into $BASE_BRANCH"
+
+  # Just attempt the merge: GitHub recomputes mergeability asynchronously after our force-push and
+  # serves the previous verdict until it settles, so checking first only reads a stale answer.
+  # --match-head-commit stops a retry merging anything but the commit we pushed.
+  local attempt merge_output pr_status state merge_state head_ref_oid
+  for ((attempt = 1; attempt <= max_attempts; attempt++)); do
+    if merge_output=$(gh pr merge "$SDK_PR_NUMBER" --repo "$GITHUB_REPOSITORY" --rebase \
+      --match-head-commit "$head_sha" 2>&1); then
+      log_info "Merged SDK PR #$SDK_PR_NUMBER into $BASE_BRANCH"
+      return 0
+    fi
+
+    pr_status=$(gh pr view "$SDK_PR_NUMBER" --repo "$GITHUB_REPOSITORY" \
+      --json state,mergeStateStatus,headRefOid \
+      --jq '[.state, .mergeStateStatus, .headRefOid] | @tsv' 2>/dev/null || true)
+    IFS=$'\t' read -r state merge_state head_ref_oid <<<"$pr_status"
+
+    # A lost response looks exactly like a failed merge, and the PR may also have been merged by
+    # hand. Either way the work is done, so check before reporting failure.
+    if [[ -n "$state" && "$state" != "OPEN" ]]; then
+      log_info "SDK PR #$SDK_PR_NUMBER is $state; nothing left to merge"
+      return 0
+    fi
+
+    # A conflict needs a human, so stop rather than spend the remaining attempts on it. Only
+    # trusted once headRefOid matches what we pushed; until then the state describes the old head.
+    if [[ "$head_ref_oid" == "$head_sha" && "$merge_state" == "DIRTY" ]]; then
+      log_error "SDK PR #$SDK_PR_NUMBER conflicts with $BASE_BRANCH; not retrying"
+      break
+    fi
+
+    log_info "Merge attempt $attempt/$max_attempts failed: $merge_output"
+    sleep "$retry_seconds"
+  done
+
+  log_error "Could not merge SDK PR #$SDK_PR_NUMBER into $BASE_BRANCH: $merge_output"
+  post_automerge_failure_comment "$(describe_unmergeable_pr)"
+  request_pr_reviewers "$SDK_PR_NUMBER" "${AUTOMERGE_FAILURE_REVIEWERS:-}"
+  return 1
+}

--- a/scripts/lib/pending-deploy-helpers.sh
+++ b/scripts/lib/pending-deploy-helpers.sh
@@ -251,5 +251,8 @@ create_pr_if_not_exists() {
   fi
 
   log_info "Created PR: $pr_url"
+
+  request_pr_reviewers "$(basename "$pr_url")" "${PENDING_DEPLOY_REVIEWERS:-}"
+
   set_output pr_url "$pr_url"
 }

--- a/scripts/openapi-sync-publish.sh
+++ b/scripts/openapi-sync-publish.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 # 1. Commits changes with generated metadata
 # 2. Pushes to fork
 # 3. Creates or updates SDK PR
+# 4. Rebase-merges the SDK PR into its pending deploy branch (merged events only)
 #
 # Environment variables:
 #   EVENT_TYPE: Type of event triggering the sync (openapi-spec-changed or openapi-spec-merged)
@@ -25,6 +26,7 @@ set -euo pipefail
 #   COMMIT_BODY: Generated commit body (when there are changes)
 #   PR_TITLE: Generated PR title (when there are changes)
 #   PR_DESCRIPTION: Generated PR description (when there are changes)
+#   AUTOMERGE_FAILURE_REVIEWERS: Comma-separated handles to request review from on automerge failure
 
 # Get the script directory
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -48,6 +50,12 @@ main() {
 
   if [[ "$HAS_CHANGES" == "false" && "$EVENT_TYPE" != "openapi-spec-merged" ]]; then
     log_info "No changes detected after syncing OpenAPI spec and regenerating client"
+  fi
+
+  # Not guarded on HAS_CHANGES: a merged event whose spec is unchanged still amends the commit
+  # to add the Managed-service-commit-SHA trailer, and that trailer has to reach the base branch.
+  if [[ "$EVENT_TYPE" == "openapi-spec-merged" ]]; then
+    automerge_sdk_pr || exit 1
   fi
 
   log_info "=== OpenAPI sync step completed: Publish ==="

--- a/scripts/pending-deploy-pr.sh
+++ b/scripts/pending-deploy-pr.sh
@@ -10,6 +10,9 @@ set -euo pipefail
 #   GITHUB_TOKEN: GitHub token for creating PRs
 #   GITHUB_REPOSITORY: Repository in owner/repo format
 #   GITHUB_OUTPUT: Path to GitHub Actions output file
+#
+# Optional environment variables:
+#   PENDING_DEPLOY_REVIEWERS: Comma-separated handles to request review from on the created PR
 
 # Get the script directory
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"


### PR DESCRIPTION
Add automerge_sdk_pr, called from the publish step for openapi-spec-merged events only, which rebase-merges the SDK PR into its pending deploy branch once the managed-service PR has landed.

Rebasing lands the PR's commits as they are, preserving the Managed-service-commit-SHA trailer that pending-deploy-check reads.

GitHub recomputes mergeability asynchronously and the publish step force-pushes moments earlier, so an upfront mergeability check would only ever read a stale answer. The merge is attempted directly and retried instead, stopping early on a conflict once GitHub reports a state for the commit we pushed.

In case of a merge failure, the workflow tags console team members.

This PR also contains updates to the pending deploy workflow to ensure console team members are tagged as reviewers when opening PRs to land changes from a pending deploy branch on main.

------


Tested a clean case and it merged as expected. Tested on a PR with a conflict and it posted the comment as expected:
[
<img width="914" height="337" alt="Screenshot 2026-08-06 at 11 26 07 PM" src="https://github.com/user-attachments/assets/db5db2d1-4e5b-4146-a76e-a33a93346ade" />
](url)